### PR TITLE
fix: clean up optional parameters signature

### DIFF
--- a/packages/react-percy-storybook/src/react-percy-storybook.d.ts
+++ b/packages/react-percy-storybook/src/react-percy-storybook.d.ts
@@ -8,7 +8,8 @@ declare module '@percy-io/react-percy-storybook' {
   }
 
   export interface PercyAddon {
-    addWithPercyOptions(storyName: string, options: PercyOptions | RenderFunction, storyFn?: RenderFunction): this;
+    addWithPercyOptions(storyName: string, storyFn: RenderFunction): this;
+    addWithPercyOptions(storyName: string, options: PercyOptions, storyFn: RenderFunction): this;
   }
 
   export interface PercyAddonContext {


### PR DESCRIPTION
Before, it was possible to pass an undefined `storyFn`.