### PR TITLE
Upgrade Yarn to 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - node_js: "8"
       env: INTEGRATION_TEST=storybook-for-vue PERCY_PROJECT=percy/storybook-for-vue PERCY_TOKEN="$STORYBOOK_FOR_VUE_PERCY_TOKEN"
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.1
   - export PATH="$HOME/.yarn/bin:$PATH"
   - yarn --version
 script:

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -9,19 +9,11 @@ error() {
   exit 1
 }
 
-link () {
-  pushd ../../packages/$1
-  yarn link
-  popd
-  yarn link @percy-io/$1
-}
-
 if [ "$SUITE" = "storybook-for-react" ]; then
   # If Percy is enabled, and there's a PERCY_TOKEN supplied (it's not on community PRs),
   # take snapshots of the storybook-for-react integration tests's stories.
   if [[ "$PERCY_ENABLE" != "0" && -n "$PERCY_TOKEN" ]] ; then
     cd integration-tests/storybook-for-react
-    link percy-storybook
     yarn storybook:percy
   elif [[ "$PERCY_ENABLE" != "0" && "$TRAVIS" != true ]] ; then
     # This is local, when invoking yarn test:integration storybook-for-react w/o PERCY_TOKEN
@@ -32,7 +24,6 @@ elif [ "$SUITE" = "storybook-for-vue" ]; then
   # take snapshots of the storybook-for-vue integration tests's stories.
   if [[ "$PERCY_ENABLE" != "0" && -n "$PERCY_TOKEN" ]] ; then
     cd integration-tests/storybook-for-vue
-    link percy-storybook
     yarn storybook:percy
   elif [[ "$PERCY_ENABLE" != "0" && "$TRAVIS" != true ]] ; then
     # This is local, when invoking yarn test:integration storybook-for-vue w/o PERCY_TOKEN


### PR DESCRIPTION
Summary
--
Upgrade to Yarn v1 in CI and get rid of the linking in integration tests now that Yarn properly maps bin files in lerna projects.