### PR TITLE
Fix when script tag includes type attribute

### DIFF
--- a/packages/percy-storybook/src/getStaticAssets.js
+++ b/packages/percy-storybook/src/getStaticAssets.js
@@ -75,7 +75,7 @@ export default function getStaticAssets(options = {}) {
 
   // Load the special static/preview.js that contains all stories
   const storybookJavascriptPath = storyHtml.match(
-    /<script src="(.*?static\/preview.*?)"><\/script>/,
+    /<script (?:type="text\/javascript" )src="(.*?static\/preview.*?)"><\/script>/,
   )[1];
   const storyJavascript = fs.readFileSync(
     path.join(storybookStaticPath, storybookJavascriptPath),


### PR DESCRIPTION
Not clear to me why my Storybook install is emitting `type="text/javascript` as part of the `script` tag, as I don't see code that does it in Storybook or a change that introduced it. But it doesn't seem like it hurts to accept it.

Without this, the `percy-storybook` command fails with:

```
Error:  TypeError: Cannot read property '1' of null
```