### PR TITLE
Add skip option to addWithPercyOptions

### DIFF
--- a/integration-tests/storybook-for-react/stories/index.js
+++ b/integration-tests/storybook-for-react/stories/index.js
@@ -89,6 +89,7 @@ storiesOf('addWithPercyOptions', module)
   ))
   .addWithPercyOptions('single width', { widths: [444] }, () => <span>Renders in one width</span>)
   .addWithPercyOptions('without options', () => <span>Renders with the fallback width(s)</span>)
+  .addWithPercyOptions('with skip option', { skip: true }, () => <span>Will not Render</span>)
   .addWithPercyOptions('with RTL of true for a single story', { rtl: true }, () => (
     <div className={direction}>
       <span>The direction is {direction}.</span>

--- a/integration-tests/storybook-for-vue/stories/index.js
+++ b/integration-tests/storybook-for-vue/stories/index.js
@@ -33,4 +33,9 @@ storiesOf('addWithPercyOptions', module)
     components: { MyButton },
     template: '<my-button @click="action">I have snapshots in a single width</my-button>',
     methods: { action: action('clicked') },
+  }))
+  .addWithPercyOptions('skipped', { skip: true }, () => ({
+    components: { MyButton },
+    template: '<my-button @click="action">I will not render</my-button>',
+    methods: { action: action('clicked') },
   }));

--- a/packages/percy-storybook/src/__tests__/selectStories-tests.js
+++ b/packages/percy-storybook/src/__tests__/selectStories-tests.js
@@ -127,4 +127,48 @@ describe('selectStories', () => {
       expect(selectStories(stories, /.*/gim)).toEqual(expectedSelectedStories);
     });
   });
+
+  describe('skip option', () => {
+    it('excludes story when enabled', () => {
+      const options = { skip: true };
+      const stories = [
+        {
+          kind: 'ImagePost',
+          stories: [{ name: 'a', options }, { name: 'b' }],
+        },
+      ];
+
+      const expectedSelectedStories = [
+        {
+          encodedParams: 'selectedKind=ImagePost&selectedStory=b',
+          name: 'ImagePost: b',
+        },
+      ];
+
+      expect(selectStories(stories)).toEqual(expectedSelectedStories);
+    });
+
+    it('trumps rtl option', () => {
+      const options = { skip: true, rtl: true };
+      const stories = [
+        {
+          kind: 'ImagePost',
+          stories: [{ name: 'a', options }, { name: 'b' }],
+        },
+      ];
+
+      const expectedSelectedStories = [
+        {
+          encodedParams: 'selectedKind=ImagePost&selectedStory=b',
+          name: 'ImagePost: b',
+        },
+        {
+          encodedParams: 'selectedKind=ImagePost&selectedStory=b&direction=rtl',
+          name: 'ImagePost: b [RTL]',
+        },
+      ];
+
+      expect(selectStories(stories, /.*/gim)).toEqual(expectedSelectedStories);
+    });
+  });
 });

--- a/packages/percy-storybook/src/percy-storybook.d.ts
+++ b/packages/percy-storybook/src/percy-storybook.d.ts
@@ -5,6 +5,7 @@ declare module '@percy-io/percy-storybook' {
   export interface PercyOptions {
     rtl?: boolean;
     widths?: number[];
+    skip?: boolean;
   }
 
   export interface PercyAddon {

--- a/packages/percy-storybook/src/selectStories.js
+++ b/packages/percy-storybook/src/selectStories.js
@@ -6,16 +6,19 @@ export default function selectStories(stories, rtlRegex) {
   let selectedStories = [];
   for (const group of stories) {
     for (const story of group.stories) {
-      const name = `${group.kind}: ${story.name}`;
-      const encodedParams =
-        `selectedKind=${encodeURIComponent(group.kind)}` +
-        `&selectedStory=${encodeURIComponent(story.name)}`;
+      const options = story.options || {};
+      if (!options.skip) {
+        const name = `${group.kind}: ${story.name}`;
+        const encodedParams =
+          `selectedKind=${encodeURIComponent(group.kind)}` +
+          `&selectedStory=${encodeURIComponent(story.name)}`;
 
-      selectedStories.push({
-        name,
-        encodedParams,
-        options: story.options,
-      });
+        selectedStories.push({
+          name,
+          encodedParams,
+          options: story.options,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This adds an option skip option to addWithPercyOptions, which excludes the story from tests. It overrides any other options for the story.

Fixes #15 