### PR TITLE
Fix rtl regex

### DIFF
--- a/packages/percy-storybook/src/__tests__/getRtlRegex-tests.js
+++ b/packages/percy-storybook/src/__tests__/getRtlRegex-tests.js
@@ -6,7 +6,7 @@ it('returns null when rtl and rtl_regex not provided', () => {
 });
 
 it('returns a regex that matches everything when rtl true', () => {
-  expect(getRtlRegex(true, null)).toEqual(/.*/gim);
+  expect(getRtlRegex(true, null)).toEqual(/.*/im);
 });
 
 it('returns a regex from the rtlRegex param', () => {
@@ -15,4 +15,12 @@ it('returns a regex from the rtlRegex param', () => {
 
 it('raises an error when both rtl and rtlRegex are provided', () => {
   expect(() => getRtlRegex(true, 'abc')).toThrow();
+});
+
+it('matches all storynames repeatedly when rtl requested - regex is not sticky', () => {
+  // This is a regression test.  We had a bug where using the g flag in the rtl regex
+  // was making the regex sticky, and causing matches on subsequently shorter names to fail
+  let rtlRegex = getRtlRegex(true, null);
+  expect(rtlRegex.test('abc')).toEqual(true);
+  expect(rtlRegex.test('ab')).toEqual(true);
 });

--- a/packages/percy-storybook/src/getRtlRegex.js
+++ b/packages/percy-storybook/src/getRtlRegex.js
@@ -5,7 +5,7 @@ export default function getRtlRegex(rtl, rtlRegex) {
 
   // If rtl is set, match all story names
   if (rtl) {
-    return /.*/gim;
+    return /.*/im;
   }
 
   if (rtlRegex) {


### PR DESCRIPTION
We had a bug where using the g flag in the rtl regex was making the regex sticky, and causing matches on subsequent names that were shorter to fail.  

The result was some RTL stories were being skipped when the --rtl option was being used.