### PR TITLE
Fix regex for parsing preview as last script on a single line

### DIFF
--- a/packages/percy-storybook/src/__tests__/getStaticAssets-tests.js
+++ b/packages/percy-storybook/src/__tests__/getStaticAssets-tests.js
@@ -29,3 +29,12 @@ it('parses and returns path when type last', () => {
     '</body></html>';
   expect(getStorybookJavascriptPath(html)).toEqual('static/preview.ca96e23c5dfccc147bb8.bundle.js');
 });
+
+it('parses and returns path when last script of multiple on one line', () => {
+  const html =
+    '<html><head></head><body>' +
+    '<script src="static/other.ca96e23c5dfccc147bb8.bundle.js" type="text/javascript"></script>' +
+    '<script src="static/preview.ca96e23c5dfccc147bb8.bundle.js" type="text/javascript"></script>' +
+    '</body></html>';
+  expect(getStorybookJavascriptPath(html)).toEqual('static/preview.ca96e23c5dfccc147bb8.bundle.js');
+});

--- a/packages/percy-storybook/src/getStaticAssets.js
+++ b/packages/percy-storybook/src/getStaticAssets.js
@@ -75,7 +75,7 @@ function gatherBuildResources(buildDir) {
 
 export function getStorybookJavascriptPath(storyHtml) {
   // Get the full static/preview script path from the storyHtml
-  return storyHtml.match(/<script [^>]*src\s*=\s*["'](.*?static\/preview.*?)["'][^>]*>/)[1];
+  return storyHtml.match(/<script [^>]*src\s*=\s*["']([^"']*static\/preview[^"']*)["'][^>]*>/)[1];
 }
 
 export default function getStaticAssets(options = {}) {


### PR DESCRIPTION
This fixes a problem with a change introduced in Storybook 3.3.

Thanks @joscha for the heads up!
 
Fixes #23  