### PR TITLE
Allow 10 seconds for stories to be set on window.

### DIFF
--- a/packages/percy-storybook/src/__tests__/getStories-tests.js
+++ b/packages/percy-storybook/src/__tests__/getStories-tests.js
@@ -1,6 +1,17 @@
 import getStories from '../getStories';
 import { storiesKey } from '../constants';
 
+let originalTimeout = 0;
+
+beforeEach(function() {
+  originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 12000;
+});
+
+afterEach(function() {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+});
+
 it('raises an error when called with an empty object', async () => {
   try {
     await getStories();

--- a/packages/percy-storybook/src/getStories.js
+++ b/packages/percy-storybook/src/getStories.js
@@ -61,28 +61,26 @@ function getStoriesFromDom(previewJavascriptCode, options) {
       src: [workerMock, localStorageMock, matchMediaMock, previewJavascriptCode],
       done: (err, window) => {
         if (err) return reject(err.response.body);
+        if (!window) return reject(new Error('Window not found when looking for stories.'));
 
-        // Check if the window has stories every 100ms for up to 10 seconds
-        // This allows 10 seconds for any async tasks (like fetch)
+        // Check if the window has stories every 100ms for up to 10 seconds.
+        // This allows 10 seconds for any async pre-tasks (like fetch) to complete.
         // Usually stories will be found on the first loop.
         var checkStories = function(timesCalled) {
-          if (!window || (timesCalled >= 100 && !window[storiesKey])) {
+          if (window[storiesKey]) {
+            // Found the stories, return them.
+            resolve(window[storiesKey]);
+          } else if (timesCalled < 100) {
+            // Stories not found yet, try again 100ms from now
+            setTimeout(() => {
+              checkStories(timesCalled + 1);
+            }, 100);
+          } else {
             // Attempted 100 times, give up.
             const message =
               'Storybook object not found on window. ' +
               "Check your call to serializeStories in your Storybook's config.js.";
             reject(new Error(message));
-          }
-          if (window[storiesKey]) {
-            // Found the stories, return them.
-            resolve(window[storiesKey]);
-          } else {
-            // Stories not found yet but no error, try again 100ms from now
-            setTimeout(() => {
-              if (timesCalled < 100) {
-                checkStories(timesCalled + 1);
-              }
-            }, 100);
           }
         };
         checkStories(0);


### PR DESCRIPTION
We have a customer who's calling fetch() before calling serializeStories, which is resulting in the stories to be set on the window a second or two after the jsDOM done callback gets called.

This PR allows 10 seconds for the stories to be set, before returning a failure.

You can test this works by updating the [serializeStories call in one of our integration tests](https://github.com/percy/percy-storybook/blob/master/integration-tests/storybook-for-react/storybook/config.js#L38) to `fetch('https://example.com').then(serializeStories(getStorybook));` and then running `storybook:percy`.

Without this PR, it fails.  With the PR, it succeeds.