### PR TITLE
Sanitize Storynames

### DIFF
--- a/integration-tests/storybook-for-react/stories/index.js
+++ b/integration-tests/storybook-for-react/stories/index.js
@@ -125,3 +125,7 @@ storiesOf('With info addon', module)
     { widths: [555] },
     withInfo('doc string about my component')(() => <span>info 555px width</span>),
   );
+
+storiesOf('@names that need sanitizing', module)
+  .add('name with "double" quotes', () => <span>Has a name with double quotes</span>)
+  .add("name with 'single' quotes", () => <span>Has a name with single quotes</span>);

--- a/integration-tests/storybook-for-react/stories/index.js
+++ b/integration-tests/storybook-for-react/stories/index.js
@@ -127,5 +127,8 @@ storiesOf('With info addon', module)
   );
 
 storiesOf('@names that need sanitizing', module)
+  .add('name with [square] brackets & {braces}', () => (
+    <span>Has a name with [square] brackets & braces</span>
+  ))
   .add('name with "double" quotes', () => <span>Has a name with double quotes</span>)
   .add("name with 'single' quotes", () => <span>Has a name with single quotes</span>);

--- a/packages/percy-storybook/package.json
+++ b/packages/percy-storybook/package.json
@@ -25,7 +25,7 @@
     "babel-register": "^6.26.0"
   },
   "dependencies": {
-    "@percy/react-percy-api-client": "^0.4.1",
+    "@percy/react-percy-api-client": "^0.4.3",
     "babel-runtime": "^6.26.0",
     "debug": "^3.1.0",
     "es6-error": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,9 +281,9 @@
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@percy-io/in-percy/-/in-percy-0.1.10.tgz#20b0f5e2b99c56cac6ce22dcd41e4e5246e1e753"
 
-"@percy/react-percy-api-client@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@percy/react-percy-api-client/-/react-percy-api-client-0.4.1.tgz#1ef1fdfbbdbd063f64e425f450348905f96d8930"
+"@percy/react-percy-api-client@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@percy/react-percy-api-client/-/react-percy-api-client-0.4.3.tgz#3375ee6ce2721c0323187df4017c13c01625b107"
   dependencies:
     babel-runtime "^6.26.0"
     debug "^2.6.3"


### PR DESCRIPTION
When a story name includes double quotes, it works correctly in Storybook itself, but causes a problem with percy-storybook.

This is because the conversion of the story name to a resource url isn't correctly sanitizing the name.  It needs to either strip the quotes and other characters, or not use the name for the url.  This is the line of code where it happens: https://github.com/percy/react-percy/blob/master/packages/react-percy-api-client/src/resources/makeRootResource.js#L4

The slugify package does have an option to remove characters, if we decide to go that route: https://www.npmjs.com/package/slugify