### PR TITLE
Update react percy api client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
     - node_js: "8"
       env: UNIT_TEST=true COVERAGE=true
     - node_js: "8"
-      env: INTEGRATION_TEST=storybook-for-react PERCY_PROJECT=percy/storybook-for-react PERCY_TOKEN="$STORYBOOK_FOR_REACT_PERCY_TOKEN"
+      env: INTEGRATION_TEST=storybook-for-react PERCY_TOKEN="$STORYBOOK_FOR_REACT_PERCY_TOKEN"
     - node_js: "8"
-      env: INTEGRATION_TEST=storybook-for-react PERCY_PROJECT=percy/storybook-for-react-chrome PERCY_TOKEN="$STORYBOOK_FOR_REACT_CHROME_PERCY_TOKEN"
+      env: INTEGRATION_TEST=storybook-for-react PERCY_TOKEN="$STORYBOOK_FOR_REACT_CHROME_PERCY_TOKEN"
     - node_js: "8"
-      env: INTEGRATION_TEST=storybook-for-vue PERCY_PROJECT=percy/storybook-for-vue PERCY_TOKEN="$STORYBOOK_FOR_VUE_PERCY_TOKEN"
+      env: INTEGRATION_TEST=storybook-for-vue PERCY_TOKEN="$STORYBOOK_FOR_VUE_PERCY_TOKEN"
     - node_js: "8"
-      env: INTEGRATION_TEST=storybook-for-angular PERCY_PROJECT=percy/storybook-for-angular PERCY_TOKEN="$STORYBOOK_FOR_ANGULAR_PERCY_TOKEN"
+      env: INTEGRATION_TEST=storybook-for-angular PERCY_TOKEN="$STORYBOOK_FOR_ANGULAR_PERCY_TOKEN"
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/HOWITWORKS.md
+++ b/HOWITWORKS.md
@@ -4,7 +4,7 @@ This repository contains the percy-storybook client in packages/percy-storybook.
 ## Tests
 After you've installed packages with `yarn`, you can:
 * run unit tests for percy-storybook with `yarn test`
-* run the integration tests by changing into the relevant folder ./integration-tests folder, exporting your Percy project and token, and running `yarn storybook:percy`.
+* run the integration tests by changing into the relevant folder ./integration-tests folder, exporting your Percy token, and running `yarn storybook:percy`.
 
 Unit tests and all 3 integration tests are configured to run in CI on both Travis and Appveyor.
 

--- a/packages/percy-storybook/package.json
+++ b/packages/percy-storybook/package.json
@@ -26,7 +26,7 @@
     "mock-fs": "^4.5.0"
   },
   "dependencies": {
-    "@percy/react-percy-api-client": "^0.4.3",
+    "@percy/react-percy-api-client": "^0.4.6",
     "babel-runtime": "^6.26.0",
     "debug": "^3.1.0",
     "es6-error": "^4.0.2",

--- a/packages/percy-storybook/src/cli.js
+++ b/packages/percy-storybook/src/cli.js
@@ -71,10 +71,6 @@ export async function run(argv) {
     throw new Error('The PERCY_TOKEN environment variable is missing.');
   }
 
-  if (!process.env.PERCY_PROJECT) {
-    throw new Error('The PERCY_PROJECT environment variable is missing.');
-  }
-
   // Not skipping, so get the iframe path and verify it exists
   options.iframePath = getIframePath(options);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,15 +281,15 @@
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@percy-io/in-percy/-/in-percy-0.1.10.tgz#20b0f5e2b99c56cac6ce22dcd41e4e5246e1e753"
 
-"@percy/react-percy-api-client@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@percy/react-percy-api-client/-/react-percy-api-client-0.4.3.tgz#3375ee6ce2721c0323187df4017c13c01625b107"
+"@percy/react-percy-api-client@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@percy/react-percy-api-client/-/react-percy-api-client-0.4.6.tgz#e2b907c39bc0b53ce2da856aad8cec7ab03dac46"
   dependencies:
     babel-runtime "^6.26.0"
     debug "^2.6.3"
     es6-promise-pool "^2.4.4"
     mime-types "^2.1.14"
-    percy-client "^2.8.2"
+    percy-client "^3.0.0"
     slugify "^1.1.0"
 
 "@schematics/angular@~0.1.12":
@@ -8998,9 +8998,9 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
-percy-client@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.8.2.tgz#2415dcc5d07bd4dea913df5f237cff4f0295839a"
+percy-client@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-3.0.0.tgz#86289f8224817cf550c9b21aaf994b7fa16f291d"
   dependencies:
     base64-js "^1.2.3"
     bluebird "^3.5.1"
@@ -9010,6 +9010,7 @@ percy-client@^2.8.2:
     regenerator-runtime "^0.11.1"
     request "^2.85.0"
     request-promise "^4.2.2"
+    walk "^2.3.14"
   optionalDependencies:
     lint-staged "^7.0.4"
 
@@ -12103,6 +12104,12 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+walk@^2.3.14:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  dependencies:
+    foreachasync "^3.0.0"
 
 walk@^2.3.9:
   version "2.3.13"


### PR DESCRIPTION
Simple PR to upgrade `react-percy-api-client` and remove references to PERCY_PROJECT