### PR TITLE
Upgrade to Storybook 4.1.0-alpha.10 in React integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   include:
     - node_js: "8"
       env: LINT=true
-    - node_js: "6"
+    - node_js: "10"
       env: UNIT_TEST=true COVERAGE=false
     - node_js: "8"
       env: UNIT_TEST=true COVERAGE=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/integration-tests/storybook-for-react/package.json
+++ b/integration-tests/storybook-for-react/package.json
@@ -20,11 +20,11 @@
   "devDependencies": {
     "@percy-io/in-percy": "^0.1.10",
     "@percy-io/percy-storybook": "^2.1.0",
-    "@storybook/addon-actions": "^4.0.0-alpha.4",
-    "@storybook/addon-info": "^4.0.0-alpha.4",
-    "@storybook/addon-knobs": "^4.0.0-alpha.4",
-    "@storybook/addon-links": "^4.0.0-alpha.4",
-    "@storybook/addon-options": "^4.0.0-alpha.4",
-    "@storybook/react": "^4.0.0-alpha.4"
+    "@storybook/addon-actions": "^4.1.0-alpha.10",
+    "@storybook/addon-info": "^4.1.0-alpha.10",
+    "@storybook/addon-knobs": "^4.1.0-alpha.10",
+    "@storybook/addon-links": "^4.1.0-alpha.10",
+    "@storybook/addon-options": "^4.1.0-alpha.10",
+    "@storybook/react": "^4.1.0-alpha.10"
   }
 }


### PR DESCRIPTION
Ensures our Storybook SDK is ready for the upcoming Storybook 4.1 release.
It also abandons running unit tests in nodejs v6 and adds them for v10.  The majority of tests are in nodejs v8.
Nodejs v6 abandonment was due to one of the upgraded sub-dependencies requiring engine 8. 