### PR TITLE
Fix page race condition

### DIFF
--- a/packages/percy-storybook/src/getStories.js
+++ b/packages/percy-storybook/src/getStories.js
@@ -56,6 +56,7 @@ export default async function getStories(options = {}) {
     // 3: Add console.log statements inside fetchStoriesFromWindow above.
     stories = await page.evaluate(fetchStoriesFromWindow);
   } finally {
+    await page.close();
     await browser.close();
   }
 


### PR DESCRIPTION
Fix for a possible issue with race condition.
I am getting a page error ```Error: Protocol error (Page.enable): Target closed.```
When running percy-storybook inside a bazel build.

Based on the following issue https://github.com/GoogleChrome/puppeteer/issues/843#issuecomment-331835527