### PR TITLE
Filter to only relevant attributes when fetching story attributes.

### DIFF
--- a/integration-tests/storybook-for-react/stories/index.js
+++ b/integration-tests/storybook-for-react/stories/index.js
@@ -146,9 +146,31 @@ storiesOf('withInfo added as decorator', module)
   .add(
     'A story with info',
     () => {
-      return <span>This story has info to test the info addon</span>;
+      return (
+        <span>
+          This story has a jsx component in the info to test story sanitation in page.evaluate
+        </span>
+      );
     },
-    { info: { text: `my inserted string: ${someOtherString}` } },
+    {
+      info: {
+        text: (
+          <>
+            <p
+              style={{
+                marginBottom: '0',
+                width: '100%',
+                textAlign: 'center',
+                padding: '100px 10px',
+                backgroundColor: '#29c2b5',
+              }}
+            >
+              my inserted string: {someOtherString}
+            </p>
+          </>
+        ),
+      },
+    },
   );
 
 storiesOf('@names that need sanitizing', module)

--- a/packages/percy-storybook/src/__tests__/getStories-tests.js
+++ b/packages/percy-storybook/src/__tests__/getStories-tests.js
@@ -25,5 +25,7 @@ it('raises an error when no stories loaded', async () => {
 
 it('returns the stories from the window', async () => {
   const stories = await getStories({ iframePath: __dirname + '/iframe.html' });
-  expect(stories).toEqual('mock window stories value');
+  expect(stories).toEqual([
+    { kind: "this is the story's kind", name: "this is the story's name", parameters: {} },
+  ]);
 });

--- a/packages/percy-storybook/src/__tests__/iframe.html
+++ b/packages/percy-storybook/src/__tests__/iframe.html
@@ -1,7 +1,11 @@
 <html>
   <head>
     <script>
-      window['__STORYBOOK_CLIENT_API__'] = { raw: function() { return 'mock window stories value'}};
+      window['__STORYBOOK_CLIENT_API__'] = { raw: function() { return [{
+        name: 'this is the story\'s name',
+        kind: 'this is the story\'s kind',
+        parameters: {}
+      }]}};
     </script>
   </head>
   <body>

--- a/packages/percy-storybook/src/constants.js
+++ b/packages/percy-storybook/src/constants.js
@@ -1,5 +1,1 @@
-export const storiesKey = '__storybook_stories__';
-
 export const storybookClientAPIKey = '__STORYBOOK_CLIENT_API__';
-export const storyStoreKey = '_storyStore';
-export const dataKey = '_data';

--- a/packages/percy-storybook/src/getStories.js
+++ b/packages/percy-storybook/src/getStories.js
@@ -16,8 +16,13 @@ const fetchStoriesFromWindow = `(async () => {
     // Usually stories will be found on the first loop.
     var checkStories = function(timesCalled) {
       if (window[storybookClientAPIKey]) {
-        // Found the stories, return them.
-        resolve(window[storybookClientAPIKey].raw());
+        // Found the stories, sanitize to name, kind, and options, and then return them.
+        var reducedStories = window[storybookClientAPIKey].raw().map(story => { return {
+          name: story.name,
+          kind: story.kind,
+          parameters: { percy: story.parameters ? story.parameters.percy : undefined },
+        }});
+        resolve(reducedStories);
       } else if (timesCalled < 100) {
         // Stories not found yet, try again 100ms from now
         setTimeout(() => {
@@ -34,7 +39,7 @@ const fetchStoriesFromWindow = `(async () => {
   });
 })()`;
 
-export default async function getStoryStory(options = {}) {
+export default async function getStories(options = {}) {
   let launchArgs = [];
 
   // Some CI platforms including Travis requires Chrome to be launched without the sandbox

--- a/packages/percy-storybook/src/getStories.js
+++ b/packages/percy-storybook/src/getStories.js
@@ -1,6 +1,6 @@
 const os = require('os');
 const puppeteer = require('puppeteer');
-import { storybookClientAPIKey, storyStoreKey, dataKey } from './constants';
+import { storybookClientAPIKey } from './constants';
 
 // The function below needs to be in a template string to prevent babel from transforming it.
 // If babel transformed it, puppeteer wouldn't be able to evaluate it properly.
@@ -9,8 +9,6 @@ import { storybookClientAPIKey, storyStoreKey, dataKey } from './constants';
 const fetchStoriesFromWindow = `(async () => {
   return await new Promise((resolve, reject) => {
     const storybookClientAPIKey = '${storybookClientAPIKey}';
-    const storyStoreKey = '${storyStoreKey}';
-    const dataKey = '${dataKey}';
     // Check if the window has stories every 100ms for up to 10 seconds.
     // This allows 10 seconds for any async pre-tasks (like fetch) to complete.
     // Usually stories will be found on the first loop.


### PR DESCRIPTION
This avoids problems of page.evaluate returning undefined if some of the other story attributes can't be serialized.  ie. when the info for a story contains a jsx fragment.