### PR TITLE
feat: fail when no stories are found

### DIFF
--- a/packages/percy-storybook/src/args.js
+++ b/packages/percy-storybook/src/args.js
@@ -1,6 +1,10 @@
 export const docs = 'Documentation: https://percy.io/percy-storybook';
 
 export const options = {
+  fail_on_empty: {
+    description: 'Fail when no stories are found',
+    requiresArg: true,
+  },
   widths: {
     alias: 'w',
     description: 'Comma seperated lists of widths',

--- a/packages/percy-storybook/src/cli.js
+++ b/packages/percy-storybook/src/cli.js
@@ -30,7 +30,9 @@ export async function run(argv) {
     .epilogue(args.docs)
     .default('build_dir', 'storybook-static')
     .default('output_format', 'text')
-    .default('minimum_height', '800').argv;
+    .default('minimum_height', '800')
+    .default('fail_on_empty', false)
+    .argv;
 
   if (argv.help) {
     yargs.showHelp();
@@ -51,6 +53,7 @@ export async function run(argv) {
     debug: argv.debug || debug.enabled,
     buildDir: argv.build_dir,
     outputFormat: getOutputFormat(argv.output_format),
+    failOnEmpty: !!argv.fail_on_empty,
   };
 
   // Enable debug logging based on options.
@@ -84,12 +87,16 @@ export async function run(argv) {
   debug('selectedStories %o', selectedStories);
 
   if (selectedStories.length === 0) {
+    const message = 'percy-storybook found no stories in the static storybook.';
+    if (options.failOnEmpty) {
+      throw new Error(message);
+    }
     if (options.outputFormat == 'text') {
       // eslint-disable-next-line no-console
-      console.log('percy-storybook found no stories in the static storybook.');
+      console.log(message);
     } else if (options.outputFormat == 'json') {
       // eslint-disable-next-line no-console
-      console.log(`{'exitReason':'percy-storybook found no stories in the static storybook.'}`);
+      console.log(JSON.stringify({ exitReason: message }));
     }
     return;
   }

--- a/packages/percy-storybook/src/cli.js
+++ b/packages/percy-storybook/src/cli.js
@@ -31,8 +31,7 @@ export async function run(argv) {
     .default('build_dir', 'storybook-static')
     .default('output_format', 'text')
     .default('minimum_height', '800')
-    .default('fail_on_empty', false)
-    .argv;
+    .default('fail_on_empty', false).argv;
 
   if (argv.help) {
     yargs.showHelp();


### PR DESCRIPTION
About three days ago we upgrade to Storybook v5, unfortunately we didn't notice that the Storybook package didn't correctly pick up the stories any more:

![Web__build_UI__78284](https://user-images.githubusercontent.com/188038/63235781-5b9a0880-c27e-11e9-8e87-5814484edb16.png)

This introduces a new CLI flag `--fail_on_empty` which will make `percy-storybook` throw if the stories could not be found.

jest and other unit testing tools fail if their test suite is empty by default (see https://github.com/facebook/jest/issues/6451) for that reason. I personally think this is how Percy should behave as well, but it is theoretically a backwards-incompatible change, so I made the newly introduced flag false by default. Let me know if you are happy to make this a breaking change and I will update the PR.

cc @diagramatics @kongakong