### PR TITLE
fix: Yargs wants flags to be strings

### DIFF
--- a/packages/percy-storybook/src/cli.js
+++ b/packages/percy-storybook/src/cli.js
@@ -31,7 +31,7 @@ export async function run(argv) {
     .default('build_dir', 'storybook-static')
     .default('output_format', 'text')
     .default('minimum_height', '800')
-    .default('fail_on_empty', false).argv;
+    .default('fail_on_empty', 'false').argv;
 
   if (argv.help) {
     yargs.showHelp();
@@ -52,7 +52,7 @@ export async function run(argv) {
     debug: argv.debug || debug.enabled,
     buildDir: argv.build_dir,
     outputFormat: getOutputFormat(argv.output_format),
-    failOnEmpty: !!argv.fail_on_empty,
+    failOnEmpty: argv.fail_on_empty === 'true',
   };
 
   // Enable debug logging based on options.


### PR DESCRIPTION
## What is this?

Even though the tests passed for #130, when merged they failed (for a good reason). Looks like yargs wants the default values to be strings rather than any other types. This PR fixes that