### PR TITLE
fix: Use story id for query format if possible

### DIFF
--- a/packages/percy-storybook/src/getStories.js
+++ b/packages/percy-storybook/src/getStories.js
@@ -15,11 +15,12 @@ const fetchStoriesFromWindow = `(async () => {
     var checkStories = function(timesCalled) {
       if (window[storybookClientAPIKey]) {
         // Found the stories, sanitize to name, kind, and options, and then return them.
-        var reducedStories = window[storybookClientAPIKey].raw().map(story => { return {
+        var reducedStories = window[storybookClientAPIKey].raw().map(story => ({
+          id: story.id,
           name: story.name,
           kind: story.kind,
           parameters: { percy: story.parameters ? story.parameters.percy : undefined },
-        }});
+        }));
         resolve(reducedStories);
       } else if (timesCalled < 100) {
         // Stories not found yet, try again 100ms from now

--- a/packages/percy-storybook/src/selectStories.js
+++ b/packages/percy-storybook/src/selectStories.js
@@ -63,9 +63,10 @@ export default function selectStories(rawStories, rtlRegex) {
     }
     if (!options.skip) {
       const name = `${story.kind}: ${story.name}`;
-      const encodedParams =
-        `selectedKind=${encodeURIComponent(story.kind)}` +
-        `&selectedStory=${encodeURIComponent(story.name)}`;
+      const encodedParams = story.id
+        ? `id=${story.id}`
+        : `selectedKind=${encodeURIComponent(story.kind)}` +
+          `&selectedStory=${encodeURIComponent(story.name)}`;
 
       selectedStories.push({
         name,


### PR DESCRIPTION
## Purpose

The `selectedKind` and `selectedStory` params are a legacy format that has issues when parameters are url-encoded. Fallback to legacy is still supported.

[Relevant comment from Storybook source](https://github.com/storybookjs/storybook/blob/5c43d0cb449845d5211870a16a141881869cd3a1/lib/core/src/client/preview/url.js#L30-L31)

Fixes #164

## Approach

Use and prefer `story.id` when storing params for selected stories. If not present, the legacy query format is still used.

### Tests

There is already a test for this. It is currently failing for new PRs. As long as all visual tests pass, this fix is verified to work.