### PR TITLE
fix: check storybook version number before using id query param

### DIFF
--- a/packages/percy-storybook/src/selectStories.js
+++ b/packages/percy-storybook/src/selectStories.js
@@ -1,4 +1,5 @@
 import ExtendableError from 'es6-error';
+import storybookVersion from './storybookVersion';
 
 export class InvalidOptionError extends ExtendableError {}
 
@@ -50,6 +51,24 @@ function storyMatchesRtlRegexAndIsNotExcluded(rtlRegex, storyName, options) {
   return rtlRegex && rtlRegex.test(storyName) && options.rtl !== false;
 }
 
+function useStoryId() {
+  if (typeof useStoryId.cached === 'boolean') {
+    return useStoryId.cached;
+  }
+
+  // ignore alpha, beta, and rc versions
+  const version = storybookVersion().split('-')[0];
+  const [major, minor] = version
+    .replace('v', '')
+    .split('.')
+    .map(Number);
+
+  // use story ID in storybook >= 5.3.x
+  const result = major >= 5 && minor >= 3;
+  useStoryId.cached = result;
+  return result;
+}
+
 export default function selectStories(rawStories, rtlRegex) {
   let selectedStories = [];
   Object.values(rawStories).forEach(story => {
@@ -63,7 +82,7 @@ export default function selectStories(rawStories, rtlRegex) {
     }
     if (!options.skip) {
       const name = `${story.kind}: ${story.name}`;
-      const encodedParams = story.id
+      const encodedParams = useStoryId()
         ? `id=${story.id}`
         : `selectedKind=${encodeURIComponent(story.kind)}` +
           `&selectedStory=${encodeURIComponent(story.name)}`;


### PR DESCRIPTION
## Purpose

In #166 preference for `id=${story.id}` was added since the old query format became a legacy format. In that PR, I incorrectly assumed that if a story had an id, then the query parameter would be accepted. That is not the case. Stories do have IDs, but the query param wasn't added until 5.3.x.

## Approach

Rather than prefer the id param when a story has an id, we should check the version of storybook and only use the id param when that version is greater than or equal to 5.3.x.

Rather than add a dependency to check for this, some string parsing is done to grab the major and minor version as numbers. The results of this check is cached so we don't need to perform the parsing for every single story.