### PR TITLE
feat: retry launching puppeteer when it fails to start

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -39,7 +39,7 @@ export const options = {
   puppeteer_launch_retries: {
     description: 'Number of times to attempt to launch puppeteer',
     requiresArg: true,
-  }
+  },
 };
 
 export const usage = 'Usage: $0 --widths=320,1280 --debug';

--- a/src/args.js
+++ b/src/args.js
@@ -36,6 +36,10 @@ export const options = {
     description: 'Runs stories with matching names a second time with direction param of rtl',
     requiresArg: true,
   },
+  puppeteer_launch_retries: {
+    description: 'Number of times to attempt to launch puppeteer',
+    requiresArg: true,
+  }
 };
 
 export const usage = 'Usage: $0 --widths=320,1280 --debug';

--- a/src/getStories.js
+++ b/src/getStories.js
@@ -38,7 +38,7 @@ const fetchStoriesFromWindow = `(async () => {
   });
 })()`;
 
-export default async function getStories(options = {}) {
+export default async function getStories(options = {}, launchPuppeteer = opts => puppeteer.launch(opts)) {
   let launchArgs = [];
 
   // Some CI platforms including Travis requires Chrome to be launched without the sandbox
@@ -48,7 +48,7 @@ export default async function getStories(options = {}) {
     launchArgs.push('--no-sandbox');
   }
 
-  const browser = await getBrowser(launchArgs, options.puppeteerLaunchRetries);
+  const browser = await getBrowser(launchPuppeteer, launchArgs, options.puppeteerLaunchRetries);
   const page = await browser.newPage();
 
   await page.goto('file://' + options.iframePath);
@@ -74,16 +74,16 @@ export default async function getStories(options = {}) {
   return stories;
 }
 
-async function getBrowser(launchArgs, retries) {
+async function getBrowser(launchPuppeteer, launchArgs, retries) {
   try {
-    return await puppeteer.launch({ headless: true, args: launchArgs });
+    return await launchPuppeteer({ headless: true, args: launchArgs });
   } catch (error) {
     if (retries <= 0) {
       throw error;
     }
 
     await sleep(1000);
-    return getBrowser(launchArgs, retries - 1);
+    return getBrowser(launchPuppeteer, launchArgs, retries - 1);
   }
 }
 

--- a/src/getStories.js
+++ b/src/getStories.js
@@ -48,7 +48,7 @@ export default async function getStories(options = {}) {
     launchArgs.push('--no-sandbox');
   }
 
-  const browser = await getBrowser(launchArgs, options.puppeteerLaunchRetries)
+  const browser = await getBrowser(launchArgs, options.puppeteerLaunchRetries);
   const page = await browser.newPage();
 
   await page.goto('file://' + options.iframePath);
@@ -85,4 +85,8 @@ async function getBrowser(launchArgs, retries) {
     await sleep(1000);
     return getBrowser(launchArgs, retries - 1);
   }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/getStories.js
+++ b/src/getStories.js
@@ -48,7 +48,7 @@ export default async function getStories(options = {}) {
     launchArgs.push('--no-sandbox');
   }
 
-  const browser = await puppeteer.launch({ headless: true, args: launchArgs });
+  const browser = await getBrowser(launchArgs, options.puppeteerLaunchRetries)
   const page = await browser.newPage();
 
   await page.goto('file://' + options.iframePath);
@@ -72,4 +72,17 @@ export default async function getStories(options = {}) {
   }
 
   return stories;
+}
+
+async function getBrowser(launchArgs, retries) {
+  try {
+    return await puppeteer.launch({ headless: true, args: launchArgs });
+  } catch (error) {
+    if (retries <= 0) {
+      throw error;
+    }
+
+    await sleep(1000);
+    return getBrowser(launchArgs, retries - 1);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,8 @@ export async function run(argv) {
     .default('build_dir', 'storybook-static')
     .default('output_format', 'text')
     .default('minimum_height', '800')
-    .default('fail_on_empty', 'false').argv;
+    .default('fail_on_empty', 'false')
+    .default('puppeteer_launch_retries', '0').argv;
 
   if (argv.help) {
     yargs.showHelp();
@@ -51,7 +52,8 @@ export async function run(argv) {
     debug: argv.debug || debug.enabled,
     buildDir: argv.build_dir,
     outputFormat: getOutputFormat(argv.output_format),
-    failOnEmpty: argv.fail_on_empty === 'true'
+    failOnEmpty: argv.fail_on_empty === 'true',
+    puppeteerLaunchRetries: parseInt(argv.pupeteer_launch_retries, 10),
   };
 
   // Enable debug logging based on options.

--- a/tests/unit/getStories-tests.js
+++ b/tests/unit/getStories-tests.js
@@ -1,3 +1,4 @@
+import puppeteer from 'puppeteer';
 import getStories from '../../src/getStories';
 
 let originalTimeout = 0;
@@ -28,4 +29,20 @@ it('returns the stories from the window', async () => {
   expect(stories).toEqual([
     { kind: "this is the story's kind", name: "this is the story's name", parameters: {} }
   ]);
+});
+
+it('retries if starting puppeteer fails', async () => {
+  let alreadyFailed = false;
+  const launchPuppeteer = opts => {
+    if (!alreadyFailed) {
+      alreadyFailed = true;
+      throw new Error('failing on purpose');
+    }
+
+    return puppeteer.launch(opts);
+  };
+
+  const options = { iframePath: __dirname + '/iframe.html', puppeteerLaunchRetries: 2 };
+  await expect(getStories(options, launchPuppeteer)).resolves.toBeTruthy();
+  expect(alreadyFailed).toBe(true);
 });

--- a/tests/unit/getStories-tests.js
+++ b/tests/unit/getStories-tests.js
@@ -46,3 +46,13 @@ it('retries if starting puppeteer fails', async () => {
   await expect(getStories(options, launchPuppeteer)).resolves.toBeTruthy();
   expect(alreadyFailed).toBe(true);
 });
+
+it('it fails after puppeteer fails to start too many times', async () => {
+  const error = new Error('failing on purpose');
+  const launchPuppeteer = () => {
+    throw error;
+  };
+
+  const options = { iframePath: __dirname + '/iframe.html', puppeteerLaunchRetries: 2 };
+  await expect(getStories(options, launchPuppeteer)).rejects.toBe(error);
+});


### PR DESCRIPTION
Hey there 👋 puppeteer is failing to launch intermittently on CI with the following error:

```
Error: Failed to launch chrome!
Inconsistency detected by ld.so: dl-tls.c: 493: _dl_allocate_tls_init: Assertion `listp->slotinfo[cnt].gen <= GL(dl_tls_generation)' failed!
TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
    at onClose (/workdir/web/node_modules/puppeteer/lib/Launcher.js:348:14)
    at ChildProcess.<anonymous> (/workdir/web/node_modules/puppeteer/lib/Launcher.js:338:60)
```

Apparently this is a [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=19329) that's not likely to be resolved. Most of the time it's fixed with a retry. As a workaround we'd like to be able to retry launching puppeteer a certain number of times, so I've added a `puppeteer_launch_retries` argument that defaults to `0`.