### PR TITLE
fix: Encode old url to prevent issues with emojis

### DIFF
--- a/src/selectStories.js
+++ b/src/selectStories.js
@@ -64,7 +64,7 @@ export default function selectStories(rawStories, rtlRegex) {
     if (!options.skip) {
       const name = `${story.kind}: ${story.name}`;
       const encodedParams = story.id
-        ? `id=${story.id}`
+        ? `id=${encodeURIComponent(story.id)}`
         : `selectedKind=${encodeURIComponent(story.kind)}` +
           `&selectedStory=${encodeURIComponent(story.name)}`;
 

--- a/tests/integration/storybook-for-react/stories/index.js
+++ b/tests/integration/storybook-for-react/stories/index.js
@@ -12,7 +12,7 @@ import faker from 'faker';
 
 storiesOf('Button', module)
   .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
-  .add('with some emoji', () => (
+  .add('with some emoji👀', () => (
     <Button onClick={action('clicked')}>
       <span role="img" aria-label="so cool">
         😀 😎 👍 💯


### PR DESCRIPTION
## What is this?

This encodes any URLs we're passing to the API to remove any special chars that might be rejected. 