### PR TITLE
♻️ Update code to accommodate core changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.52",
-    "@percy/core": "^1.0.0-beta.52",
-    "@percy/logger": "^1.0.0-beta.52",
+    "@percy/cli-command": "^1.0.0-beta.55",
+    "@percy/core": "^1.0.0-beta.55",
+    "@percy/logger": "^1.0.0-beta.55",
     "cross-spawn": "^7.0.3",
     "qs": "^6.10.1",
     "serve-handler": "^6.1.3"

--- a/src/command.js
+++ b/src/command.js
@@ -95,7 +95,7 @@ export default class StorybookCommand extends Command {
 
   // Resolves to an array of story pages to snapshot
   async getStoryPages(url) {
-    let previewUrl = new URL('/iframe.html', url);
+    let previewUrl = new URL('/iframe.html', url).href;
     let stories = await this.getStories(previewUrl);
 
     let conf = this.percy.config.storybook || {};

--- a/src/command.js
+++ b/src/command.js
@@ -59,47 +59,43 @@ export default class StorybookCommand extends Command {
     if (!l) return this.error('No snapshots found');
 
     let dry = this.flags['dry-run'];
-    if (!dry) await this.start();
+    if (dry) this.log.info(`Found ${l} snapshot${l === 1 ? '' : 's'}`);
+    else await this.start();
 
-    this.log.info(`Found ${l} snapshot${l === 1 ? '' : 's'}`);
-
-    await Promise.all(pages.map(page => {
-      if (!dry) return this.snapshot(page);
-      this.log.info(`Snapshot found: ${page.name}`);
-      this.log.debug(`-> url: ${page.url}`);
-      return Promise.resolve();
-    }));
+    for (let page of pages) {
+      if (dry) {
+        this.log.info(`Snapshot found: ${page.name}`);
+        this.log.debug(`-> url: ${page.url}`);
+      } else {
+        this.percy.snapshot(page);
+      }
+    }
   }
 
   // Called to start Percy
   async start() {
     // patch client to override root resources when JS is enabled
-    this.percy.client.sendSnapshot = options => {
+    this.percy.client.sendSnapshot = (buildId, options) => {
       if (options.enableJavaScript && this.preview) {
         Object.assign(options.resources.find(r => r.root), this.preview);
       }
 
       let { sendSnapshot } = this.percy.client.constructor.prototype;
-      return sendSnapshot.call(this.percy.client, options);
+      return sendSnapshot.call(this.percy.client, buildId, options);
     };
 
     await this.percy.start();
   }
 
-  // Called to snapshot a page
-  async snapshot(page) {
-    await this.percy.capture(page);
-  }
-
   // Called on error, interupt, or after running
-  async finally() {
-    await this.percy?.stop();
-    await this.percy?.discoverer.close();
+  async finally(error) {
+    await this.percy?.stop(!!error);
+    await this.percy?.browser.close();
   }
 
   // Resolves to an array of story pages to snapshot
   async getStoryPages(url) {
-    let previewUrl = url.replace(/\/?$/, '/iframe.html');
+    let previewUrl = new URL('/iframe.html', url);
     let stories = await this.getStories(previewUrl);
 
     let conf = this.percy.config.storybook || {};
@@ -117,20 +113,40 @@ export default class StorybookCommand extends Command {
       if (include?.length ? !include.some(i => i.test(name)) : skip) return;
       if (exclude?.some(e => e.test(name))) return;
 
+      // add query params to the url
       (queryParams ||= {}).id = id;
       if (args) queryParams.args = buildArgsParam({}, args);
       let url = `${previewUrl}?${qs.stringify(queryParams)}`;
 
+      // remove options that might cause issues
+      delete opts.domSnapshot;
+      delete opts.execute;
+
+      if (opts.snapshots) {
+        this.log.deprecated('The `snapshots` option will be ' + (
+          'removed in 4.0.0. Use `additionalSnapshots` instead.'));
+        delete opts.snapshots;
+      }
+
       return { ...opts, name, url };
     };
 
-    return stories.reduce((all, { id, snapshots = [], ...options }) => all.concat(
-      storyPage(id, options.name, options),
-      snapshots.map(({ name, prefix, suffix, ...opts }) => {
-        name ||= `${prefix || ''}${options.name}${suffix || ''}`;
-        return storyPage(id, name, merge({}, options, opts));
-      })
-    ), []).filter(Boolean);
+    return stories.reduce((all, params) => {
+      let { id, additionalSnapshots = [], ...options } = params;
+
+      // deprecation will log later
+      if (options.snapshots) {
+        additionalSnapshots = options.snapshots;
+      }
+
+      return all.concat(
+        storyPage(id, params.name, options),
+        additionalSnapshots.map(({ name, prefix, suffix, ...opts }) => {
+          name ||= `${prefix || ''}${params.name}${suffix || ''}`;
+          return storyPage(id, name, merge({}, options, opts));
+        })
+      );
+    }, []).filter(Boolean);
   }
 
   // Resolves to an array of Storybook stories
@@ -147,9 +163,9 @@ export default class StorybookCommand extends Command {
       this.preview = { content: previewDOM, sha: sha256hash(previewDOM) };
       clearTimeout(logTimeout);
 
-      // borrow a discoverer page to discover stories
-      await this.percy.discoverer.launch();
-      page = await this.percy.discoverer.page({ meta });
+      // borrow a browser page to discover stories
+      await this.percy.browser.launch();
+      page = await this.percy.browser.page({ meta });
       await page.goto(previewUrl);
 
       /* istanbul ignore next: no instrumenting injected code */

--- a/src/commands/storybook/index.js
+++ b/src/commands/storybook/index.js
@@ -21,8 +21,8 @@ export class Storybook extends Command {
   log = logger('cli:storybook');
 
   // Called on error, interupt, or after running
-  async finally() {
-    await super.finally();
+  async finally(error) {
+    await super.finally(error);
     this.server?.close();
   }
 

--- a/test/.storybook/args.stories.js
+++ b/test/.storybook/args.stories.js
@@ -15,7 +15,7 @@ export default {
     percy: {
       name: 'Args',
       skip: true,
-      snapshots: [{
+      additionalSnapshots: [{
         prefix: 'Custom ',
         args: {
           text: 'Snapshot custom args',

--- a/test/.storybook/deprecated.stories.js
+++ b/test/.storybook/deprecated.stories.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const Deprecated = () => (
+  <p>I have deprecated options!</p>
+);
+
+export default {
+  title: 'Deprecated',
+  component: Deprecated,
+  parameters: {
+    percy: { skip: true }
+  }
+};
+
+export const Snapshots = () => (
+  <Deprecated/>
+);
+
+Snapshots.parameters = {
+  percy: {
+    snapshots: [{
+      suffix: ' option'
+    }]
+  }
+};

--- a/test/.storybook/main.js
+++ b/test/.storybook/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: ['*.stories.js'],
   features: {
-    postcss: false,
+    postcss: false
   }
 };

--- a/test/storybook-start.test.js
+++ b/test/storybook-start.test.js
@@ -26,19 +26,15 @@ describe('percy storybook:start', () => {
   it('starts storybook and snapshots stories', async () => {
     await Start.run([...args]);
 
-    expect(logger.stderr).toEqual([
-      '[percy] Waiting on a response from Storybook...'
-    ]);
+    expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       `[percy] Running "start-storybook --ci --host=localhost --port=9000 ${args.join(' ')}"`,
       '[percy] Percy has started!',
-      '[percy] Created build #1: https://percy.io/test/test/123',
-      '[percy] Found 3 snapshots',
+      '[percy] Processing 3 snapshots...',
       '[percy] Snapshot taken: Snapshot: First',
       '[percy] Snapshot taken: Snapshot: Second',
       '[percy] Snapshot taken: Skip: But Not Me',
-      '[percy] Finalized build #1: https://percy.io/test/test/123',
-      '[percy] Done!'
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
 

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -54,13 +54,11 @@ describe('percy storybook', () => {
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Percy has started!',
-      '[percy] Created build #1: https://percy.io/test/test/123',
-      '[percy] Found 3 snapshots',
+      '[percy] Processing 3 snapshots...',
       '[percy] Snapshot taken: Snapshot: First',
       '[percy] Snapshot taken: Snapshot: Second',
       '[percy] Snapshot taken: Skip: But Not Me',
-      '[percy] Finalized build #1: https://percy.io/test/test/123',
-      '[percy] Done!'
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
 
@@ -70,13 +68,11 @@ describe('percy storybook', () => {
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Percy has started!',
-      '[percy] Created build #1: https://percy.io/test/test/123',
-      '[percy] Found 3 snapshots',
+      '[percy] Processing 3 snapshots...',
       '[percy] Snapshot taken: Snapshot: First',
       '[percy] Snapshot taken: Snapshot: Second',
       '[percy] Snapshot taken: Skip: But Not Me',
-      '[percy] Finalized build #1: https://percy.io/test/test/123',
-      '[percy] Done!'
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
 
@@ -185,7 +181,7 @@ describe('percy storybook', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Found 1 snapshot',
+      '[percy] Processing 1 snapshot...',
       '[percy] Snapshot taken: Skip: But Not Me'
     ]));
   });
@@ -195,7 +191,7 @@ describe('percy storybook', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Found 2 snapshots',
+      '[percy] Processing 2 snapshots...',
       '[percy] Snapshot taken: Skip: Skipped',
       '[percy] Snapshot taken: Skip: But Not Me'
     ]));
@@ -210,6 +206,16 @@ describe('percy storybook', () => {
       '[percy] Snapshot found: Snapshot: First',
       '[percy] Snapshot found: Snapshot: Second',
       '[percy] Snapshot found: Skip: But Not Me'
+    ]));
+
+    // coverage for `snapshot(s)` log
+    logger.reset();
+    await Storybook.run(['http://localhost:9000', '--dry-run', '--include=First']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Found 1 snapshot',
+      '[percy] Snapshot found: Snapshot: First'
     ]));
   });
 

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -242,4 +242,18 @@ describe('percy storybook', () => {
         encodeURIComponent('style.fontWeight:bold;style.color:purple')
     ]));
   });
+
+  it('logs a warning when using the deprecated `snapshots` option', async () => {
+    await Storybook.run(['http://localhost:9000', '--dry-run', '--include=Deprecated']);
+
+    expect(logger.stderr).toEqual([
+      '[percy] Warning: The `snapshots` option will be ' +
+        'removed in 4.0.0. Use `additionalSnapshots` instead.'
+    ]);
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Found 2 snapshots',
+      '[percy] Snapshot found: Deprecated: Snapshots',
+      '[percy] Snapshot found: Deprecated: Snapshots option'
+    ]));
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,65 +1493,65 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
-"@percy/cli-command@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.0.0-beta.52.tgz#f0ef7fecba9f549a7b06ddd06d2d70edd9b3c615"
-  integrity sha512-44n4EqyF96qDlHs9JMdixdQ+Kany1AS3fTCVE4FDARMFcZuHeFUZv4PGlRr7FUffdp8p+Qw3/hNneapYklms+w==
+"@percy/cli-command@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.0.0-beta.55.tgz#0c9bd252acbf227d63b19f4e684e8a035bb0ae1b"
+  integrity sha512-P1PQW1kDANr5cGs08HGkd7XwJM839mZAqL6YUCqdYUd7OB4SGLQSGnPmaTB8fWzQxQB/eD+iCJ3fPicAvPvr7A==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1.17.0"
     "@oclif/plugin-help" "^3.2.0"
-    "@percy/config" "^1.0.0-beta.52"
-    "@percy/logger" "^1.0.0-beta.52"
+    "@percy/config" "^1.0.0-beta.55"
+    "@percy/logger" "^1.0.0-beta.55"
 
-"@percy/client@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.0.0-beta.52.tgz#d82082cf5bbace6cc64a493af07913c92725bc72"
-  integrity sha512-PB8JGOeK0PY89cDeAo6urcdHxVVvDSJksx1vkg4AlNWkk1bitx3NngpAfR3HpWB1Efe9rW0k5mtt/h5p38KufA==
+"@percy/client@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.0.0-beta.55.tgz#e32e06cc5316ce8575c8421d384c07257668d14a"
+  integrity sha512-BykmzlwfbpvNl2QYxggZphN6QWY41gdK79U0kDwo5OFsO2RmAA7tYWrnDPYJl6ZuiDXRnng8ptrZvwOrKmlfkw==
   dependencies:
-    "@percy/env" "^1.0.0-beta.52"
+    "@percy/env" "^1.0.0-beta.55"
+    "@percy/logger" "^1.0.0-beta.55"
 
-"@percy/config@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.52.tgz#75f765cd69c78886455f96b65a85f674d30b6c8f"
-  integrity sha512-3YS+UGI9lgV3wn7ayKwSDncccHumqUaUr7oC1qDu+TowCkW6K4iwzlNVYaEFJOAwvdXtkreP6aIx/fXJAdTZ/A==
+"@percy/config@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.55.tgz#e3ffe870a092bd2b358f8988244165c335d22cf2"
+  integrity sha512-UNjuK8RRP6BopA4ZvxIsjWKNO1o/HU17336atp09Xw7w97FUtc6EvHKCBJJnOL7phsJHsmS7YimUyLCF+RxwVw==
   dependencies:
-    "@percy/logger" "^1.0.0-beta.52"
+    "@percy/logger" "^1.0.0-beta.55"
     ajv "^8.0.5"
     cosmiconfig "^7.0.0"
     yaml "^1.10.0"
 
-"@percy/core@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.0.0-beta.52.tgz#37b678692c4e024585be91595b370cc4b449ec5c"
-  integrity sha512-U/TkV7FEwJKonPh1gV6KQhK0zWq8RLwnfxpSJG9x4quyeM7JR+O+xeacC9shCJc079AqGNfLEuob3AZMLV52kA==
+"@percy/core@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.0.0-beta.55.tgz#d0d454f12cb3f3b76897ca0acefa41c3c9202f59"
+  integrity sha512-QrHnrsEBSxFokNjKZ38GDOVYGbxXNt+C6VjOfZ6+ZosjV7GJSAm7cgBzo45btfUMylpe/kV2xKlFuAthyq+0kg==
   dependencies:
-    "@percy/client" "^1.0.0-beta.52"
-    "@percy/config" "^1.0.0-beta.52"
-    "@percy/dom" "^1.0.0-beta.52"
-    "@percy/logger" "^1.0.0-beta.52"
+    "@percy/client" "^1.0.0-beta.55"
+    "@percy/config" "^1.0.0-beta.55"
+    "@percy/dom" "^1.0.0-beta.55"
+    "@percy/logger" "^1.0.0-beta.55"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
-    progress "^2.0.3"
     rimraf "^3.0.2"
     ws "^7.4.1"
 
-"@percy/dom@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.0.0-beta.52.tgz#e698aec7272be7f2743aba8d91e6f92872703120"
-  integrity sha512-1JQQWfx48m8dEi//0yB2gpGmgkdVqJoybizU/tts63CQ0PnMDS3M6MGpSbDNGuEaizoBSNnDoCOqKGgL+twDow==
+"@percy/dom@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.0.0-beta.55.tgz#49959f8f25b53e9a206136d60027d21581992b03"
+  integrity sha512-TB0YRMemPyN+eYTYfprSwRvTjRssiHnA8IPjf5VPPg5O41/Ulzh+O4RlaUlS5vJxJ/JQhNbvdVRqtR2OjAWmUQ==
 
-"@percy/env@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.0.0-beta.52.tgz#104132bc70b04185a55b2f154a1c933d9b25dbf7"
-  integrity sha512-1AjGbIsBTqnBEGY92IeKgWoQmasewSbwefIXtyn+ET1XTRDV4CUzveAlgncnZgdON4e3Ufz5SL8BoNjxhNf9aw==
+"@percy/env@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.0.0-beta.55.tgz#f2c373d855f26ba6996aa40f98ee00f5b7745930"
+  integrity sha512-MZTptXE08/gCZ2vPXTw6zm+bPWsHPxu0r5/AtzwEY+8UtxLkXtLkf6JCyeQIJnGVuUnLCxB9x6SHcq74qrensA==
   dependencies:
     dotenv "^10.0.0"
 
-"@percy/logger@^1.0.0-beta.52":
-  version "1.0.0-beta.52"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.52.tgz#d040d216c68436fc332cad6dfe4e3ae4da10e807"
-  integrity sha512-R7puXEaA1xQM2EWS7wXrWhgLTKre73pmDoY7fyAljHFYdP2IblMVOmT4eUw2D7PS5B5MDS158cYMOT2BjrPTIw==
+"@percy/logger@^1.0.0-beta.55":
+  version "1.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.55.tgz#d9e1ce43800aae5ce6f21e8e4c6b63ffb61dea4b"
+  integrity sha512-AKaleHpJf8Og0uDuX8XXLzzCj3+S/XGtWqN5G1lyW19WbANFIui9GcAmYWDqIoQh+wVdDq9b1PLGUBTkX4g3HQ==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
@@ -7897,7 +7897,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0, progress@^2.0.3:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==


### PR DESCRIPTION
## What is this?

`@percy/core` has some nice recent changes to the internal queue that we need to account for here.

- First, rather than mapping and awaiting on captures, we can synchronously queue them with the improved snapshot method. When `percy.stop()` is eventually called via `finally()`, it will wait for all queued snapshots. When called with an error, it will dequeue all snapshots and attempt to finalize any build immediately.

- The `client.sendSnapshot()` patch needed to be updated to account for a `buildId` parameter.

- Now that the `percy.capture()` method has been merged with `percy.snapshot()`, we should remove a couple of options that could potentially cause issues if provided. Mainly, the `domSnapshot` and `execute` options. We could potentially allow `execute`, but I think it may be confusing that it runs in a different context and won't have access to any local references such as variables or imports.

- The `snapshots` option was renamed to match core's `additionalSnapshots` option. If `snapshots` is provided by a non-skipped story, a single deprecation warning will be logged while collecting snapshots. 

- The `storybook:start` command will now wait for the preview iframe to become available before continuing to start percy. While the main command will always wait for the same thing, it also logs a warning when storybook takes a bit to respond. With the `:start` command, this warning is sometimes logged while storybook is still compiling. The preview is awaited on because I found the root URL to resolve long before storybook is actually ready.