### PR TITLE
🔇 Remove deprecated `snapshots` option & logs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -66,19 +66,7 @@ export const storyParamsSchema = {
   }
 };
 
-export function storyParamsMigration(config, { map, log }) {
-  if (config.snapshots) {
-    log.deprecated('The `snapshots` option will be ' + (
-      'removed in 4.0.0. Use `additionalSnapshots` instead.'));
-    map('snapshots', 'additionalSnapshots');
-  }
-}
-
 export const schemas = [
   configSchema,
   storyParamsSchema
-];
-
-export const migrations = [
-  ['/storybook', storyParamsMigration]
 ];

--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -5,5 +5,4 @@ import * as StorybookConfig from '../config';
 export default function() {
   PercyConfig.addSchema(CoreConfig.schemas);
   PercyConfig.addSchema(StorybookConfig.schemas);
-  PercyConfig.addMigration(StorybookConfig.migrations);
 }

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -243,20 +243,6 @@ describe('percy storybook', () => {
     ]));
   });
 
-  it('logs a warning when using the deprecated `snapshots` option', async () => {
-    await Storybook.run(['http://localhost:9000', '--dry-run', '--include=Options: Deprecated']);
-
-    expect(logger.stderr).toEqual([
-      '[percy] Warning: The `snapshots` option will be ' +
-        'removed in 4.0.0. Use `additionalSnapshots` instead.'
-    ]);
-    expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Found 2 snapshots',
-      '[percy] Snapshot found: Options: Deprecated',
-      '[percy] Snapshot found: Options: Deprecated (snapshots)'
-    ]));
-  });
-
   it('logs a warning when using invalid percy options', async () => {
     await Storybook.run(['http://localhost:9000', '--dry-run', '--include=Options: Invalid']);
 


### PR DESCRIPTION
## What is this?

The deprecated `snapshots` option (now `additionalSnapshots`) no longer needs to hang around now that we're on a stable release. 