### PR TITLE
🐛 Fix error when no percy options are provided

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -94,7 +94,8 @@ export default class StorybookCommand extends Command {
     let stories = await this.getStories(previewUrl);
     let validated = new Set();
 
-    let storyPage = (id, name, options) => {
+    // istanbul note: default options cannot be tested with our current storybook fixture
+    let storyPage = (id, name, /* istanbul ignore next */ options = {}) => {
       // pluck out storybook specific options
       let { skip, args, queryParams, include, exclude, ...opts } = options;
 


### PR DESCRIPTION
## What is this?

Attempting to replicate an issue somebody was seeing and I found a bug when `percy` Storybook options are missing.

Because our Storybook fixture defines top-level `percy` parameters, this default value cannot be tested without creating and building an entire second Storybook fixture. Felt a little overkill for simply testing `options ||= {}`, so I ignored coverage for it.