### PR TITLE
🐛 Gather Storybook version for SDK UA

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -11,6 +11,12 @@ import pkg from '../package.json';
 
 // used to deserialize regular expression strings
 const RE_REGEXP = /^\/(.+)\/(\w+)?$/;
+const WAIT_FOR_TIMEOUT = 5000;
+
+// remove stack traces from any eval error
+function normalizeEvalError(error) {
+  return error.replace(/^Error:\s(.*?)\n\s{4}at\s.*$/s, '$1');
+}
 
 export default class StorybookCommand extends Command {
   static flags = {
@@ -48,7 +54,7 @@ export default class StorybookCommand extends Command {
     });
 
     let url = await this.storybook();
-    // borrow a browser page to discover stories
+    // borrow a browser page to get the storybook version and discover stories
     await this.percy.browser.launch();
     let [version, pages] = await Promise.all([this.getStorybookVersion(url), this.getStoryPages(url)]);
     let l = pages.length;
@@ -192,22 +198,16 @@ export default class StorybookCommand extends Command {
       await page.goto(previewUrl);
 
       /* istanbul ignore next: no instrumenting injected code */
-      return await page.eval(async ({ waitFor }, previewUrl) => {
+      return await page.eval(async ({ waitFor }, waitForTimeout) => {
         // ensure the page has loaded and the var we need is present
-        await waitFor(() => !!window.__STORYBOOK_CLIENT_API__, 5000)
+        await waitFor(() => !!window.__STORYBOOK_CLIENT_API__, waitForTimeout)
           .catch(() => Promise.reject(new Error(
             'Storybook object not found on the window. ' +
             'Open Storybook and check the console for errors.'
           )));
+
         let serializeRegExp = r => r && [].concat(r).map(r => r.toString());
         let storybook = window.__STORYBOOK_CLIENT_API__;
-
-        if (!storybook) {
-          throw new Error(
-            'Storybook object not found on the window. ' +
-            'Open Storybook and check the console for errors.'
-          );
-        }
 
         return storybook.raw().map(({ id, kind, name, parameters }) => ({
           name: `${kind}: ${name}`,
@@ -216,11 +216,11 @@ export default class StorybookCommand extends Command {
           exclude: serializeRegExp(parameters?.percy?.exclude),
           id
         }));
-      });
+      }, WAIT_FOR_TIMEOUT);
     } catch (error) {
       // remove stack traces from any eval error
       if (typeof error === 'string') {
-        throw new Error(error.replace(/^Error:\s(.*?)\n\s{4}at\s.*$/s, '$1'));
+        throw new Error(normalizeEvalError(error));
       } else {
         throw error;
       }
@@ -231,23 +231,28 @@ export default class StorybookCommand extends Command {
 
   async getStorybookVersion(url) {
     let version, page;
+    let aboutUrl = new URL('?path=/settings/about', url).href;
 
     try {
       page = await this.percy.browser.page();
-      this.log.debug(`Get Storybook version: ${url}/?path=/settings/about`);
+      this.log.debug(`Get Storybook version: ${aboutUrl}`);
 
-      await page.goto(`${url}/?path=/settings/about`);
+      await page.goto(aboutUrl);
       /* istanbul ignore next: no instrumenting injected code */
-      version = await page.eval(async ({ waitFor }) => {
-        await waitFor(() => !!document.querySelector('header'), 5000)
-          .catch(() => Promise.reject(new Error('Failed to find a <header> element')));
+      version = await page.eval(async ({ waitFor }, waitForTimeout) => {
+        let headerPath = "//header[starts-with(text(), 'Storybook ')]";
         let getPath = path => document.evaluate(path, document, null, 9, null).singleNodeValue;
-        let text = getPath("//header[starts-with(text(), 'Storybook ')]").innerText;
 
-        return text.match(/[-]{0,1}[\d]*[.]{0,1}[\d]+/g, '').join('');
-      });
+        await waitFor(() => getPath(headerPath), waitForTimeout)
+          .catch(() => Promise.reject(new Error('Failed to find a <header> element')));
+
+        return getPath(headerPath)
+          .innerText
+          .match(/[-]{0,1}[\d]*[.]{0,1}[\d]+/g, '')
+          .join('');
+      }, WAIT_FOR_TIMEOUT);
     } catch (error) {
-      this.log.debug(`Couldn't retrieve Storybook version: ${error.message}`);
+      this.log.debug(`Couldn't retrieve Storybook version: ${normalizeEvalError(error)}`);
       version = 'unknown';
     } finally {
       await page?.close();

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -181,9 +181,7 @@ describe('percy storybook', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(mockAPI.requests['/builds/123/snapshots'].map(req => req.headers['user-agent'])[0])
-      .toMatch(
-        /^Percy\/v1 @percy\/client\/\S+ @percy\/storybook\/\d+\.\d+\.\d+.*? \(storybook\/\d+\.\d+\.\d+.*?; node\/v[\d.]+.*\)$/
-      );
+      .toMatch(/storybook\/\d+\.\d+\.\d+.*?;/);
   });
 
   it('excludes stories from snapshots with --exclude', async () => {

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -176,6 +176,16 @@ describe('percy storybook', () => {
     ]);
   });
 
+  it('sends the version of storybook when creating snapshots', async () => {
+    await Storybook.run(['http://localhost:9000']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(mockAPI.requests['/builds/123/snapshots'].map(req => req.headers['user-agent'])[0])
+      .toMatch(
+        /^Percy\/v1 @percy\/client\/\S+ @percy\/storybook\/\d+\.\d+\.\d+.*? \(storybook\/\d+\.\d+\.\d+.*?; node\/v[\d.]+.*\)$/
+      );
+  });
+
   it('excludes stories from snapshots with --exclude', async () => {
     await Storybook.run(['http://localhost:9000', '--exclude=Snapshot', '--exclude=Options']);
 


### PR DESCRIPTION
## What is this?

Currently we're not collecting the version of Storybook when creating builds. This makes it a little harder to provide support (and becomes a question to the customer rather than us just having it). 

The version is missing from v4 because how we gathered the version in the past was a bit cumbersome. It would look at the dependency tree and try to match a storybook framework version. There's no single package for us to import to get the version from. 

The way we grab the version now is by visiting the `?path=/settings/about` route and plucking the version from the DOM. Storybook uses this route to show the current version & does a version check. 

A small improvement was made to how we get gather the stories off of the `window` object. We now use the `waitFor` util to double check the var is present _before_ trying to capture the stories. Helpful for remote storybooks that take a bit longer to load/render.

Probably should merge/release this before this CLI PR (to avoid warnings) https://github.com/percy/cli/pull/479