### PR TITLE
✨ Use discovery auth headers for protected Storybooks

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,118 @@
+import logger from '@percy/logger';
+import PercyConfig from '@percy/config';
+import { merge } from '@percy/config/dist/utils';
+import { buildArgsParam } from '@storybook/router/utils';
+import qs from 'qs';
+
+// Returns true or false if the provided story should be skipped by matching against include and
+// exclude filter options. If any global filters are provided, they will override story filters.
+function shouldSkipStory(story, config) {
+  let { skip, include, exclude } = story;
+
+  let matches = regexp => {
+    /* istanbul ignore else: sanity check */
+    if (typeof regexp === 'string') {
+      let [, parsed, flags] = /^\/(.+)\/(\w+)?$/.exec(regexp) || [];
+      regexp = new RegExp(parsed ?? regexp, flags);
+    }
+
+    return regexp?.test?.(story.name);
+  };
+
+  // if a global filter is present, override story filters
+  if (config?.include || config?.exclude) {
+    include = [].concat(config.include).filter(Boolean);
+    exclude = [].concat(config.exclude).filter(Boolean);
+  }
+
+  // if included, don't skip; if excluded always exclude
+  skip = include?.length ? !include.some(matches) : skip;
+  if (!skip && !exclude?.some(matches)) return false;
+  return true;
+}
+
+// Returns snapshot config options for a Storybook story merged with global Storybook
+// options. Validation error messages will be added to the provided validations set.
+function getSnapshotConfig(story, config, validations) {
+  let { id, ...options } = PercyConfig.migrate(story, '/storybook');
+
+  for (let e of (PercyConfig.validate(options, '/storybook') || [])) {
+    validations.add(`- percy.${e.path}: ${e.message}`);
+  }
+
+  return merge([config, options, { id }], (path, prev, next) => {
+    // normalize, but do not merge include or exclude options
+    if (path.length === 1 && ['include', 'exclude'].includes(path[0])) {
+      return [path, [].concat(next).filter(Boolean)];
+    }
+  });
+}
+
+// Prunes non-snapshot options and adds a URL generated from story args and query params.
+function toStorySnapshot(story, url) {
+  let {
+    id, args, queryParams,
+    skip, include, exclude,
+    ...snapshot
+  } = story;
+
+  let params = { ...queryParams, id };
+  if (args) params.args = buildArgsParam({}, args);
+  let storyPreview = `iframe.html?${qs.stringify(params)}`;
+  snapshot.url = new URL(storyPreview, url).href;
+
+  return snapshot;
+}
+
+// Reduces Storybook story options to snapshot options, including variations in story URLs due to
+// story args and other query params.
+export async function mapStorySnapshots(stories, { url, config }) {
+  let log = logger('storybook:config');
+  let validations = new Set();
+
+  let snapshots = stories.reduce((all, story) => {
+    if (shouldSkipStory(story, config)) {
+      log.debug(`Skipping story: ${story.name}`);
+      return all;
+    }
+
+    let { additionalSnapshots = [], ...options } =
+      getSnapshotConfig(story, config, validations);
+
+    return all.concat(
+      toStorySnapshot(options, url),
+      additionalSnapshots.reduce((add, snap) => {
+        let { prefix = '', suffix = '', ...opts } = snap;
+        let name = `${prefix}${story.name}${suffix}`;
+        opts = merge([options, { name }, opts]);
+
+        if (shouldSkipStory(opts, config)) {
+          log.debug(`Skipping story: ${opts.name}`);
+          return add;
+        }
+
+        return add.concat(toStorySnapshot(opts, url));
+      }, []));
+  }, []);
+
+  if (validations.size) {
+    log.warn('Invalid Storybook parameters:');
+    for (let msg of validations) log.warn(msg);
+  }
+
+  return snapshots;
+}
+
+// Transforms authorization credentials into a basic auth header and returns all config request
+// headers with the additional authorization header if not already set.
+export function getAuthHeaders(config) {
+  let headers = { ...config.requestHeaders };
+  let auth = config.authorization;
+
+  if (auth && !(headers.authorization || headers.Authorization)) {
+    let creds = auth.username + (auth.password ? `:${auth.password}` : '');
+    headers.Authorization = `Basic ${Buffer.from(creds).toString('base64')}`;
+  }
+
+  return headers;
+}

--- a/test/storybook-start.test.js
+++ b/test/storybook-start.test.js
@@ -43,8 +43,7 @@ describe('percy storybook:start', () => {
     setTimeout(() => fakeProc.emit('error', new Error('FAKE ENOENT')), 100);
     mockRequire('cross-spawn', () => fakeProc);
 
-    await expectAsync(Start.run([...args]))
-      .toBeRejectedWithError('EEXIT: 1');
+    await expectAsync(Start.run([...args])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stdout).toEqual([
       `[percy] Running "start-storybook --ci --host=localhost --port=9000 ${args.join(' ')}"`


### PR DESCRIPTION
## Purpose

When we borrow a page from the core discovery browser to scrape for the Storybook version and stories, we do so without providing any page options. This is because those options are mostly only relevant during asset discovery, and while scraping for information we do not need or want to perform any asset discovery.

However, some hosted Storybooks are served behind some form of authentication. As such, we need to provide authorization credentials and potentially other request headers to the borrowed discovery page.

Closes #425 

## Approach

Rather than duplicate all the config necessary to provide in the various required places, I refactored the version and story scraping functions to dry them up. There is now an `_eval` method that accepts a URL and function to evaluate on the borrowed page after navigation. The page is created with appropriate discovery options that may effect how the page loads. This new method also allows us to move a helper and constant at the top of the file into this method since it's the only place they would now be used.

With regards to `authorization` credentials, this discovery option is only used during request interception and so cannot be provided to the borrowed page since we do not want to intercept requests. However, we can automatically convert those credentials into an auth header and provide that header with any others to the borrowed page.

These headers needed to be provided to two other places in addition to the borrowed page: to the request made when using the `storybook:start` which waits for the build to be accessible, and to the request made when fetching the preview DOM used during client snapshot patching. These two other requests were refactored into a single method called during the `startStorybook` methods, and the waiting log timeout was moved into the start command.

Finally, with many new methods added to the base command class, I saw an opportunity to trim up the file and move several other methods into functional utils. During all of this refactoring, I also removed this SDKs own dry-run handling in favor of relying on core's new internal dry-run handling. 