### PR TITLE
🐛 Add missing tests and miscellaneous fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,4 @@ jobs:
         env:
           PERCY_POSTINSTALL_BROWSER: true
       - run: yarn build
-      - run: yarn test
-        env:
-          DUMP_FAILED_TEST_LOGS: true
+      - run: yarn test:coverage

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "^1.6.0",
+    "@percy/cli-command": "^1.6.3",
     "@storybook/router": "^6.5.0",
     "cross-spawn": "^7.0.3"
   },

--- a/src/common.js
+++ b/src/common.js
@@ -15,20 +15,25 @@ export const flags = [{
 }, {
   name: 'shard-count',
   description: 'Number of shards to split snapshots into',
+  validate: (count, { operators }) => (process.env.PERCY_PARALLEL_TOTAL ||= ((
+    // default total to -1 for partial builds or the provided the count otherwise
+    Array.from(operators.entries()).find(a => a[0].name === 'partial')?.[1]
+  ) ? '-1' : `${count}`)),
   parse: v => parseInt(v, 10),
   type: 'number'
 }, {
   name: 'shard-size',
   description: 'Size of each shard to split snapshots into',
+  validate: () => (process.env.PERCY_PARALLEL_TOTAL ||= '-1'),
   parse: v => parseInt(v, 10),
   type: 'number'
 }, {
   name: 'shard-index',
   description: 'Index of the shard to take snapshots of',
-  parse: v => (process.env.PERCY_PARALLEL_TOTAL ||= '-1') && parseInt(v, 10),
+  parse: v => parseInt(v, 10),
   type: 'index'
 }, {
   name: 'partial',
   description: 'Marks the build as a partial build',
-  parse: () => !!(process.env.PERCY_PARTIAL_BUILD ||= '1')
+  validate: () => (process.env.PERCY_PARTIAL_BUILD ||= '1')
 }];

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -106,9 +106,13 @@ function mapStorybookSnapshots(stories, config, flags) {
     snapshots = shardSnapshots(snapshots, flags, log);
   }
 
-  // error when missing snapshots and remove used filter options
+  // error when missing snapshots
   if (!snapshots.length) throw new Error('No snapshots found');
-  return snapshots.map(({ skip, include, exclude, ...s }) => s);
+
+  // remove filter options and generate story snapshot URLs
+  return snapshots.map(({ skip, include, exclude, ...s }) => ({
+    url: buildStoryUrl(previewUrl, s), ...s
+  }));
 }
 
 // Collects Storybook snapshots, sets environment info, and patches client to optionally deal with

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -71,7 +71,7 @@ function shardSnapshots(snapshots, { shardSize, shardCount, shardIndex }) {
 }
 
 // Map and reduce collected Storybook stories into an array of snapshot options
-function mapStorybookSnapshots(stories, config, flags) {
+function mapStorybookSnapshots(stories, { previewUrl, flags, config }) {
   let log = logger('storybook:config');
   let validations = new Set();
 
@@ -115,63 +115,72 @@ function mapStorybookSnapshots(stories, config, flags) {
   }));
 }
 
-// Collects Storybook snapshots, sets environment info, and patches client to optionally deal with
-// JavaScript enabled Storybook stories.
-export async function* takeStorybookSnapshots(percy, { baseUrl, flags }) {
-  let aboutUrl = new URL('?path=/settings/about', baseUrl).href;
-  let previewUrl = new URL('iframe.html', baseUrl).href;
-  let log = logger('storybook');
-  let lastCount;
+// Starts the percy instance and collects Storybook snapshots, calling the callback when done
+export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags }) {
+  try {
+    let aboutUrl = new URL('?path=/settings/about', baseUrl).href;
+    let previewUrl = new URL('iframe.html', baseUrl).href;
+    let log = logger('storybook');
+    let lastCount;
 
-  log.debug(`Requesting Storybook: ${baseUrl}`);
-  // start a timeout to show a log if storybook takes a few seconds to respond
-  let logTimeout = setTimeout(log.warn, 3000, 'Waiting on a response from Storybook...');
-  let previewResource = yield fetchStorybookPreviewResource(percy, previewUrl);
-  clearTimeout(logTimeout);
+    log.debug(`Requesting Storybook: ${baseUrl}`);
+    // start a timeout to show a log if storybook takes a few seconds to respond
+    let logTimeout = setTimeout(log.warn, 3000, 'Waiting on a response from Storybook...');
+    let previewResource = yield fetchStorybookPreviewResource(percy, previewUrl);
+    clearTimeout(logTimeout);
 
-  // launch the percy browser if not launched during dry-runs
-  yield percy.browser.launch();
+    // start percy
+    yield* percy.yield.start();
+    // launch the percy browser if not launched during dry-runs
+    yield percy.browser.launch();
 
-  // gather storybook data in parallel
-  let [environmentInfo, stories] = yield Promise.all([
-    withPage(percy, aboutUrl, p => p.eval(evalStorybookEnvironmentInfo)),
-    withPage(percy, previewUrl, async p => mapStorybookSnapshots(
-      await p.eval(evalStorybookStorySnapshots),
-      percy.config.storybook, flags
-    ))
-  ]);
+    // gather storybook data in parallel
+    let [environmentInfo, stories] = yield Promise.all([
+      withPage(percy, aboutUrl, p => p.eval(evalStorybookEnvironmentInfo)),
+      withPage(percy, previewUrl, async p => mapStorybookSnapshots(
+        await p.eval(evalStorybookStorySnapshots), {
+          previewUrl, flags, config: percy.config.storybook
+        }))
+    ]);
 
-  // set storybook environment info
-  percy.setConfig({ environmentInfo });
+    // set storybook environment info
+    percy.setConfig({ environmentInfo });
 
-  // use a single page to capture story snapshots without reloading
-  yield withPage(percy, previewUrl, async page => {
-    // determines when to retry page crashes
-    lastCount = stories.length;
+    // use a single page to capture story snapshots without reloading
+    yield withPage(percy, previewUrl, async page => {
+      // determines when to retry page crashes
+      lastCount = stories.length;
 
-    while (stories.length) {
-      // separate story and snapshot options
-      let { id, args, globals, queryParams, ...options } = stories[0];
-      let story = { id, args, globals, queryParams };
-      let url = await buildStoryUrl(previewUrl, story);
+      while (stories.length) {
+        // separate story and snapshot options
+        let { id, args, globals, queryParams, ...options } = stories[0];
+        // when javascript is enabled, the preview dom is used
+        let domSnapshot = previewResource.content;
 
-      // when javascript is enabled, the preview dom is used
-      let domSnapshot = previewResource.content;
+        // when javascript is not enabled and not dry-running, take a dom snapshot of the story
+        if (!(flags.dryRun || options.enableJavaScript || percy.config.snapshot.enableJavaScript)) {
+          await page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
+          ({ dom: domSnapshot } = await page.snapshot(options));
+        }
 
-      // when javascript is not enabled, or when dry-running, take a dom snapshot of the story
-      if (!(flags.dryRun || options.enableJavaScript || percy.config.snapshot.enableJavaScript)) {
-        await page.eval(evalSetCurrentStory, story);
-        ({ dom: domSnapshot } = await page.snapshot(options));
+        // snapshots are queued and do not need to be awaited on
+        percy.snapshot({ domSnapshot, ...options });
+        // discard this story when done
+        stories.shift();
       }
+    }, () => {
+      log.debug(`Page crashed while loading story: ${stories[0].id}`);
+      // return true to retry as long as the length decreases
+      return lastCount > stories.length;
+    });
 
-      // snapshots are queued and do not need to be awaited on
-      percy.snapshot({ url, domSnapshot, ...options });
-      // discard this story when done
-      stories.shift();
-    }
-  }, () => {
-    log.debug(`Page crashed while loading story: ${stories[0].id}`);
-    // return true to retry as long as the length decreases
-    return lastCount > stories.length;
-  });
+    // will stop once snapshots are done processing
+    yield* percy.yield.stop();
+  } catch (error) {
+    // force stop and re-throw
+    await percy.stop(true);
+    throw error;
+  } finally {
+    await callback();
+  }
 }

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -112,7 +112,7 @@ function mapStorybookSnapshots(stories, config, flags) {
   }
 
   // maybe split snapshots into shards
-  if (flags.shardSize || flags.shardCount || flags.shardIndex) {
+  if ((flags.shardSize || flags.shardCount || flags.shardIndex) != null) {
     snapshots = shardSnapshots(snapshots, flags, log);
   }
 

--- a/src/start.js
+++ b/src/start.js
@@ -39,22 +39,9 @@ export const start = command('start', {
     spawn('start-storybook', args, { stdio: 'inherit' }).on('error', reject)
   ));
 
-  try {
-    yield* percy.yield.start();
-
-    yield* takeStorybookSnapshots(percy, {
-      /* istanbul ignore next: this is a storybook flag we don't need to test */
-      baseUrl: `${argv.includes('--https') ? 'https' : 'http'}://${host}:${port}`,
-      flags
-    });
-
-    yield* percy.yield.stop();
-  } catch (error) {
-    await percy.stop(true);
-    throw error;
-  } finally {
-    proc.kill();
-  }
+  /* istanbul ignore next: this is a storybook flag we don't need to test */
+  let baseUrl = `${argv.includes('--https') ? 'https' : 'http'}://${host}:${port}`;
+  yield* takeStorybookSnapshots(percy, () => proc.kill(), { baseUrl, flags });
 });
 
 export default start;

--- a/src/start.js
+++ b/src/start.js
@@ -24,7 +24,7 @@ export const start = command('start', {
   ],
 
   percy: {
-    deferUploads: true
+    delayUploads: true
   }
 }, async function*({ percy, flags, argv, log, exit }) {
   if (!percy) exit(0, 'Percy is disabled');

--- a/src/storybook.js
+++ b/src/storybook.js
@@ -24,7 +24,7 @@ export const storybook = command('storybook', {
   ],
 
   percy: {
-    deferUploads: true
+    delayUploads: true
   },
 
   config: {

--- a/src/storybook.js
+++ b/src/storybook.js
@@ -39,21 +39,10 @@ export const storybook = command('storybook', {
   let { createServer } = yield import('@percy/cli-command/utils');
   let server = args.serve && await createServer(args).listen();
 
-  try {
-    yield* percy.yield.start();
-
-    yield* takeStorybookSnapshots(percy, {
-      baseUrl: args.url ?? server?.address(),
-      flags
-    });
-
-    yield* percy.yield.stop();
-  } catch (error) {
-    await percy.stop(true);
-    throw error;
-  } finally {
-    await server?.close();
-  }
+  yield* takeStorybookSnapshots(percy, () => server?.close(), {
+    baseUrl: args.url ?? server?.address(),
+    flags
+  });
 });
 
 export default storybook;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import { request, createRootResource } from '@percy/cli-command/utils';
+import { buildArgsParam } from '@storybook/router';
 
 // Transforms authorization credentials into a basic auth header and returns all config request
 // headers with the additional authorization header if not already set.
@@ -15,27 +16,12 @@ function getAuthHeaders(config) {
 }
 
 // Build a url for storybook to determine initial state from
-export async function buildStoryUrl(baseUrl, story) {
-  let { buildArgsParam } = await import('@storybook/router');
-  let url = new URL(baseUrl);
-
-  url.searchParams.set('id', story.id);
-
-  if (story.globals) {
-    url.searchParams.set('globals', buildArgsParam({}, story.globals));
-  }
-
-  if (story.args) {
-    url.searchParams.set('args', buildArgsParam({}, story.args));
-  }
-
-  if (story.queryParams) {
-    for (let [param, value] in Object.entries(story.queryParams)) {
-      url.searchParams.set(param, value);
-    }
-  }
-
-  return url.href;
+export function buildStoryUrl(baseUrl, story) {
+  let url = `${baseUrl}?id=${story.id}`;
+  if (story.args) url += `&args=${buildArgsParam(null, story.args)}`;
+  if (story.globals) url += `&globals=${buildArgsParam(null, story.globals)}`;
+  if (story.queryParams) url += `&${new URLSearchParams(story.queryParams)}`;
+  return url;
 }
 
 // Fetch the raw Storybook preview resource to use when JS is enabled

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,10 +101,19 @@ export function evalSetCurrentStory({ waitFor }, story) {
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'
   ))).then(channel => {
+    // emit a series of events to render the desired story
     channel.emit('updateGlobals', { globals: {} });
     channel.emit('setCurrentStory', { storyId: story.id });
     channel.emit('updateQueryParams', { ...story.queryParams });
     channel.emit('updateGlobals', { globals: story.globals });
     channel.emit('updateStoryArgs', { storyId: story.id, updatedArgs: story.args });
+
+    // resolve when rendered, reject on any other renderer event
+    return new Promise((resolve, reject) => {
+      channel.on('storyRendered', resolve);
+      channel.on('storyMissing', reject);
+      channel.on('storyErrored', reject);
+      channel.on('storyThrewException', reject);
+    });
   });
 }

--- a/test/.storybook/mixed.stories.js
+++ b/test/.storybook/mixed.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export const Params = ({ text }, { globals }) => {
+  let param = new URLSearchParams(window.location.search).get('text') || '';
+  return (<p>{text}{globals.text}{param}</p>);
+};
+
+Params.args = {
+  text: 'Mixed params'
+};
+
+export default {
+  title: 'Mixed',
+  component: Params,
+  parameters: {
+    percy: {
+      name: 'From params',
+      skip: true,
+      additionalSnapshots: [{
+        suffix: ' w/ globals',
+        globals: { text: ' with globals' }
+      }, {
+        suffix: ' w/ query params',
+        queryParams: { text: ' with query params' }
+      }, {
+        suffix: ' w/ mixed params',
+        args: { text: 'Args' },
+        globals: { text: ' globals' },
+        queryParams: { text: ' and params' }
+      }]
+    }
+  }
+};

--- a/test/storybook-start.test.js
+++ b/test/storybook-start.test.js
@@ -14,6 +14,7 @@ describe('percy storybook:start', () => {
   });
 
   afterEach(() => {
+    delete process.env.PERCY_ENABLE;
     delete process.env.PERCY_TOKEN;
   });
 
@@ -54,6 +55,16 @@ describe('percy storybook:start', () => {
     ]);
     expect(logger.stderr).toEqual([
       '[percy] Error: FAKE ENOENT'
+    ]);
+  });
+
+  it('does nothing when percy is disabled', async () => {
+    process.env.PERCY_ENABLE = '0';
+    await start(['http://localhost:9000']);
+
+    expect(logger.stdout).toEqual([]);
+    expect(logger.stderr).toEqual([
+      '[percy] Percy is disabled'
     ]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,42 +1441,42 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@percy/cli-command@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.0.tgz#3227e5429adfaf1ff8bd170df571f72c46286beb"
-  integrity sha512-seJ3bkRKS1Nmf9GLE1K5Mqvl01MdejmWD9c6kuYcJndGGkwp6xqUDjhbtIHPxFp1UOTa7b6cb0CT6o01C7VjmQ==
+"@percy/cli-command@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.3.tgz#e209cd4410cd8b6a0e130f48258173080bcdce96"
+  integrity sha512-WHICKTVdLW8vFm0emBkR/tV14XKWUfUEKw9UieSuEwIrQmMTPEaY0GxuRk3NrBMj6vkRuJW6yeLCGLVWFlRGlQ==
   dependencies:
-    "@percy/config" "1.6.0"
-    "@percy/core" "1.6.0"
-    "@percy/logger" "1.6.0"
+    "@percy/config" "1.6.3"
+    "@percy/core" "1.6.3"
+    "@percy/logger" "1.6.3"
 
-"@percy/client@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.0.tgz#33470d20891ddfcfc4a3f1a6d3c2b0c404eada75"
-  integrity sha512-pUC1ZUaCpHcKCORIOrE/Y2+7LgELGX/s0X3INCFMIiFcgQK+FyQAjV+0x4MG+FJJvtxfj5WoP4LVu1XWlbyHrg==
+"@percy/client@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.3.tgz#7d75af3b92e3548fae70239cc16e4a832ae520e6"
+  integrity sha512-/gsfhikO3O36vWHH6TQ4QSVp/i1GkTt7lyPEn51jzKjV9rdQ8hmvxzMk2mleyYDAlZQBwyQaOZdMnhfbphLM2w==
   dependencies:
-    "@percy/env" "1.6.0"
-    "@percy/logger" "1.6.0"
+    "@percy/env" "1.6.3"
+    "@percy/logger" "1.6.3"
 
-"@percy/config@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.0.tgz#5e720c76fca8cb8872257b3a6630ffad1fce4e36"
-  integrity sha512-g5wDYRqyrSxoTszLxmw/cb1DIjuc91uYQZNVjNc7TWtX8Rvlvbr1fOhaLq5/bmB8N6kLP2sXmcdz9zO4Fuw53g==
+"@percy/config@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.3.tgz#381e2b1f64593b651c90aeca911979cae5867f3f"
+  integrity sha512-BKDykqRoBrjeUHhfYLuTrAnxFYTuOXHc6XKmHuui44buoF5ZaG/2Md5DQpqfGVQ0Jdzumoge/up7PGmxdve1SQ==
   dependencies:
-    "@percy/logger" "1.6.0"
+    "@percy/logger" "1.6.3"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.0.tgz#ff2c29a11883f6251a5e664dfb130a1296f69a99"
-  integrity sha512-pXqzmg84cQO39xAT90RChnh7R2Xfv7e3Tu0z1/pEO7/TbxAbMFN5xjLYEXExmbvRlBZ1aMlhjfeHMcMWodyC8A==
+"@percy/core@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.3.tgz#a22c12e09d1e43aa6e72494ce94acae7beb8923d"
+  integrity sha512-RwRh8UUARv2gtD32C0NNe6VbBAWhne6IUBN5nMJ2yw6Q7LZqf2oa8kiocxGlyXpMTjYDRZ/FbNT0PqFw5o52gw==
   dependencies:
-    "@percy/client" "1.6.0"
-    "@percy/config" "1.6.0"
-    "@percy/dom" "1.6.0"
-    "@percy/logger" "1.6.0"
+    "@percy/client" "1.6.3"
+    "@percy/config" "1.6.3"
+    "@percy/dom" "1.6.3"
+    "@percy/logger" "1.6.3"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -1487,20 +1487,20 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.0.tgz#15a9363ad45757b71287fa0ef982f58d69877311"
-  integrity sha512-yy5BCSTS6q0aOaA0v5kthgl/Ap8GPTJNfjmMTZxOjsxZ5WpVWWgMItkLo/sWcV77YJQG+Q343xCd/+thH393NA==
+"@percy/dom@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.3.tgz#cd2bf2569ba328f886ba9e026498a060fd980ffc"
+  integrity sha512-V4D/og0AOI1uFb5xtRYuypjmG6PuVwe+eMz10hFThRsxCiRGKlS7QnZUyNQkRwIO/k2r7LnboBpIUzBakSCgzA==
 
-"@percy/env@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.0.tgz#47cc9a886a3ab1045c1bbff30831fad16abb485a"
-  integrity sha512-nQpAspFtKdU7fwyVyEY+JtWMohrRfPug6osLRV6DmZnBvT9SLJ4Fh67W06xOGL6PBGiWLuCKyS5d7tJi+WWkUw==
+"@percy/env@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.3.tgz#ab9ff1f3cd85d77be409206d6469fa580efe5164"
+  integrity sha512-YsGQa6i/8Ca+XblRFxAClIo18dEYrU/rZKTZEio4WJ59zjoTskOU3VTgH4a4LX7J3LRpy0+A3v8UiUI4y3Vf8g==
 
-"@percy/logger@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.0.tgz#09653444013ba3bae152543c8721e6c9e025d2d5"
-  integrity sha512-4Y3dQdVDgFtEHtou2IVSNqaxGNOp0QeVWGx/4wbxchrPh8fXpBcXuYRHQRgpH+vDlb8pdx7cOFSlGJuOXN8LMw==
+"@percy/logger@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.3.tgz#c13c64c20f9f842fe36266abbddfe9f07cfd2b6a"
+  integrity sha512-900DQ6KmDZVADuVdPARpZHvodALrswLOd/z4x2du484o/hyiNtO2nvO3rzyTCPVI+nreMT82yCy3JqnNwtJaSQ==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
## What is this?

With #592, it was discovered that this SDK was actually missing quite a bit of tests. Since it was out of scope for that PR, we opted to address this in another PR (this PR).

With the addition of new tests to achieve 100% coverage, a few small bugs inevitably came up and were fixed.

- When splitting snapshots into shards with `--shard-count`, providing the `--partial` flag will now always set the parallel total environment variable to `-1` unless already set. Previously, the `--shard-count` flag did not consider the `--partial` flag when setting the environment variable.

- When creating the story URL and settings params with the native URLSearchParams API, it will encode any provided values. However, args and globals params are already encoded, therefore resulting in double encoding of those params. This was fixed with string concatenation for already encoded values, while still using the URLSearchParams API for provided query params.

- Both the `storybook` and `storybook:start` commands have similar try-catch blocks to start Percy and call the same utility function with a different `baseUrl`. The try-catch repetition was moved into the utility function which now accepts a callback that is called during the `finally` block.

- The `deferUploads` option was changed to the new `delayUploads` option so snapshots get sent to the API as soon as possible rather than all at once at the end of the process. Uploads are still delayed rather than be left eager so empty builds are not created when failing to find any snapshots or Storybook build.

- A new event listener was added to the end of story navigation, which will wait until Storybook emits a `storyRendered` event before taking a snapshot. While network idle is always awaited on, this might help in situations when no network requests occur, which may cause the snapshot to be taken too early when no other wait options are provided.