### PR TITLE
♻️ Remove dependency on storybook param util

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "^1.6.3",
-    "@storybook/router": "^6.5.0",
-    "cross-spawn": "^7.0.3"
+    "@percy/cli-command": "^1.6.4",
+    "cross-spawn": "^7.0.3",
+    "qs": "^6.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.6",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 import { request, createRootResource } from '@percy/cli-command/utils';
-import { buildArgsParam } from '@storybook/router';
 
 // Transforms authorization credentials into a basic auth header and returns all config request
 // headers with the additional authorization header if not already set.
@@ -15,15 +14,6 @@ function getAuthHeaders(config) {
   return headers;
 }
 
-// Build a url for storybook to determine initial state from
-export function buildStoryUrl(baseUrl, story) {
-  let url = `${baseUrl}?id=${story.id}`;
-  if (story.args) url += `&args=${buildArgsParam(null, story.args)}`;
-  if (story.globals) url += `&globals=${buildArgsParam(null, story.globals)}`;
-  if (story.queryParams) url += `&${new URLSearchParams(story.queryParams)}`;
-  return url;
-}
-
 // Fetch the raw Storybook preview resource to use when JS is enabled
 export async function fetchStorybookPreviewResource(percy, previewUrl) {
   return createRootResource(previewUrl, await request(previewUrl, {
@@ -32,6 +22,76 @@ export async function fetchStorybookPreviewResource(percy, previewUrl) {
     interval: 1000,
     retries: 30
   }));
+}
+
+// Used during args/globals validation, encoding, and decoding
+const VAL_REG = /^[a-zA-Z0-9 _-]*$/;
+const NUM_REG = /^-?[0-9]+(\.[0-9]+)?$/;
+const HEX_REG = /^#([a-f0-9]{3,4}|[a-f0-9]{6}|[a-f0-9]{8})$/i;
+const COL_REG = /^(rgba?|hsla?)\(([0-9]{1,3}),\s*([0-9]{1,3})%?,\s*([0-9]{1,3})%?,?\s*([0-9]?(\.[0-9]{1,2})?)?\)$/i;
+const VALID_REG = new RegExp([VAL_REG, NUM_REG, HEX_REG, COL_REG].map(r => r.source).join('|'), 'i');
+
+function isPlainObject(obj) {
+  return (typeof obj === 'object' && (
+    Object.getPrototypeOf(obj) === null ||
+    Object.getPrototypeOf(obj) === Object.prototype
+  ));
+}
+
+// Validate story args & globals like storybook
+export function validateStoryArgs(key, value) {
+  if (key == null || key === '' || !VAL_REG.test(key)) return false;
+  if (value == null || value instanceof Date) return true;
+  if (typeof value === 'number' || typeof value === 'boolean') return true;
+  if (typeof value === 'string') return VALID_REG.test(value);
+  if (Array.isArray(value)) return value.every(v => validateStoryArgs(key, v));
+  if (isPlainObject(value)) return Object.entries(value).every(e => validateStoryArgs(...e));
+  return false;
+}
+
+// Encode story args & globals like storybook
+export function encodeStoryArgs(value) {
+  if (value == null) return `!${value}`;
+  if (value instanceof Date) return `!date(${value.toISOString()})`;
+  if (typeof value === 'string' && HEX_REG.test(value)) return `!hex(${value.slice(1)})`;
+  if (typeof value === 'string' && COL_REG.test(value)) return `!${value.replace(/\s|%/g, '')}`;
+
+  if (Array.isArray(value)) {
+    return value.map(encodeStoryArgs);
+  } else if (isPlainObject(value)) {
+    return Object.entries(value).reduce((acc, [k, v]) => (
+      Object.assign(acc, { [k]: encodeStoryArgs(v) })
+    ), {});
+  } else {
+    return value;
+  }
+}
+
+// Decode story args & globals from encoded values
+export function decodeStoryArgs(value) {
+  if (typeof value === 'string') {
+    if (value === '!null') return null;
+    if (value === '!undefined') return undefined;
+    if (value.startsWith('!date(')) return new Date(value.slice(6, -1));
+    if (value.startsWith('!hex(')) return `#${value.slice(5, -1)}`;
+
+    if (COL_REG.test(value.slice(1))) {
+      let c = value.slice(1).match(COL_REG);
+      let p = c[1][0] === 'h' ? '%' : '';
+      let a = c[1][3] === 'a' ? `, ${c[5]}` : '';
+      return `${c[1]}(${c[2]}, ${c[3]}${p}, ${c[4]}${p}${a})`;
+    }
+
+    return NUM_REG.test(value) ? Number(value) : value;
+  } else if (Array.isArray(value)) {
+    return value.map(decodeStoryArgs);
+  } else if (isPlainObject(value)) {
+    return Object.entries(value).reduce((acc, [k, v]) => (
+      Object.assign(acc, { [k]: decodeStoryArgs(v) })
+    ), {});
+  } else {
+    return value;
+  }
 }
 
 // Borrows a percy discovery browser page to navigate to a URL and evaluate a function, returning
@@ -44,6 +104,24 @@ export async function withPage(percy, url, callback, retry) {
     userAgent: percy.config.discovery.userAgent
   });
 
+  // patch eval to include storybook specific helpers in the local scope
+  page.eval = (fn, ...args) => page.constructor.prototype.eval.call(page, (
+    typeof fn === 'string' ? fn : [
+      'function withPercyStorybookHelpers() {',
+      `  const VAL_REG = ${VAL_REG};`,
+      `  const NUM_REG = ${NUM_REG};`,
+      `  const HEX_REG = ${HEX_REG};`,
+      `  const COL_REG = ${COL_REG};`,
+      `  const VALID_REG = ${VALID_REG};`,
+      `  return (${fn})(...arguments);`,
+      `  ${isPlainObject}`,
+      `  ${validateStoryArgs}`,
+      `  ${encodeStoryArgs}`,
+      `  ${decodeStoryArgs}`,
+      '}'
+    ].join('\n')
+  ), ...args);
+
   try {
     await page.goto(url);
     return await callback(page);
@@ -52,8 +130,13 @@ export async function withPage(percy, url, callback, retry) {
     if (error.message?.includes('crashed') && retry?.()) return withPage(...arguments);
     /* istanbul ignore next: purposefully not handling real errors */
     if (typeof error !== 'string') throw error;
-    // make eval errors nicer by stripping the stack trace from the message
-    throw new Error(error.replace(/^Error:\s(.*?)\n\s{4}at\s.*$/s, '$1'));
+
+    throw new Error(error.replace(
+      // strip generic error names and confusing stack traces
+      /^Error:\s((.+?)\n\s+at\s.+)$/s,
+      // keep the stack trace if the error came from a client script
+      /\n\s+at\s.+?\(https?:/.test(error) ? '$1' : '$2'
+    ));
   } finally {
     // always clean up and close the page
     await page?.close();
@@ -68,10 +151,32 @@ export function evalStorybookEnvironmentInfo({ waitForXPath }) {
     .catch(() => 'storybook/unknown');
 }
 
-// Evaluate and return Storybook stories to snapshot
+// Evaluate and return serialized Storybook stories to snapshot
 /* istanbul ignore next: no instrumenting injected code */
 export function evalStorybookStorySnapshots({ waitFor }) {
-  let serializeRegExp = r => r && [].concat(r).map(r => r.toString());
+  let serialize = (what, value, invalid) => {
+    if (what === 'include' || what === 'exclude') {
+      return [].concat(value).filter(Boolean).map(v => v.toString());
+    } else if (what === 'args' || what === 'globals') {
+      return encodeStoryArgs(Object.entries(value).reduce((acc, [k, v]) => {
+        if (validateStoryArgs(k, v)) return Object.assign(acc, { [k]: v });
+        invalid.set(`${what}.${k}`, `omitted potentially unsafe ${what.slice(0, -1)}`);
+        return acc;
+      }, {}));
+    } else if (what === 'queryParams') {
+      return Object.entries(value).reduce((acc, [k, v]) => (
+        Object.assign(acc, { [k]: encodeURIComponent(v) })
+      ), {});
+    } else if (what === 'additionalSnapshots') {
+      return value.map(s => serialize('snapshot', s, invalid));
+    } else if (what === 'snapshot') {
+      return Object.entries(value).reduce((acc, [k, v], i, a) => (
+        Object.assign(acc, { [k]: serialize(k, v, invalid) })
+      ), {});
+    } else {
+      return value;
+    }
+  };
 
   return waitFor(async () => {
     // use newer storybook APIs before old APIs
@@ -81,16 +186,23 @@ export function evalStorybookStorySnapshots({ waitFor }) {
   }, 5000).catch(() => Promise.reject(new Error(
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'
-  ))).then(stories => stories.map(story => ({
-    name: `${story.kind}: ${story.name}`,
-    ...story.parameters?.percy,
-    include: serializeRegExp(story.parameters?.percy?.include),
-    exclude: serializeRegExp(story.parameters?.percy?.exclude),
-    id: story.id
-  })));
+  ))).then(stories => {
+    let invalid = new Map();
+
+    let data = stories.map(story => serialize('snapshot', {
+      name: `${story.kind}: ${story.name}`,
+      ...story.parameters?.percy,
+      id: story.id
+    }, invalid));
+
+    return {
+      invalid: Array.from(invalid),
+      data
+    };
+  });
 }
 
-// Change the currently selected story within Storybook
+// Change the currently selected story within Storybook, decoding args and globals as necessary
 /* istanbul ignore next: no instrumenting injected code */
 export function evalSetCurrentStory({ waitFor }, story) {
   return waitFor(() => (
@@ -101,12 +213,14 @@ export function evalSetCurrentStory({ waitFor }, story) {
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'
   ))).then(channel => {
+    let { id, queryParams, globals, args } = story;
+
     // emit a series of events to render the desired story
     channel.emit('updateGlobals', { globals: {} });
-    channel.emit('setCurrentStory', { storyId: story.id });
-    channel.emit('updateQueryParams', { ...story.queryParams });
-    channel.emit('updateGlobals', { globals: story.globals });
-    channel.emit('updateStoryArgs', { storyId: story.id, updatedArgs: story.args });
+    channel.emit('setCurrentStory', { storyId: id });
+    channel.emit('updateQueryParams', { ...queryParams });
+    if (globals) channel.emit('updateGlobals', { globals: decodeStoryArgs(globals) });
+    if (args) channel.emit('updateStoryArgs', { storyId: id, updatedArgs: decodeStoryArgs(args) });
 
     // resolve when rendered, reject on any other renderer event
     return new Promise((resolve, reject) => {

--- a/test/.storybook/args.stories.js
+++ b/test/.storybook/args.stories.js
@@ -42,6 +42,22 @@ export default {
             color: 'purple'
           }
         }
+      }, {
+        prefix: 'Special ',
+        args: {
+          null: null,
+          undefined: undefined,
+          smallNum: 3,
+          largeNum: 12_000_000,
+          date: new Date('2022-01-01T00:00Z'),
+          rgb: 'rgb(20, 30, 40)',
+          rgba: 'rgba(20, 30, 40, .5)',
+          hsl: 'hsl(120, 80%, 30%)',
+          hsla: 'hsla(120, 80%, 30%, .5)',
+          shortHex: '#c6c',
+          longHex: '#a907cf',
+          alphaHex: '#a907cf9f'
+        }
       }]
     }
   }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,0 +1,102 @@
+import { validateStoryArgs, encodeStoryArgs, decodeStoryArgs } from '../src/utils.js';
+
+describe('Unit /', () => {
+  describe('validateStoryArgs', () => {
+    it('returns false when the key is empty or invalid', () => {
+      expect(validateStoryArgs(null, 'value')).toBe(false);
+      expect(validateStoryArgs(undefined, 'value')).toBe(false);
+      expect(validateStoryArgs('', 'value')).toBe(false);
+      expect(validateStoryArgs('!@#$', 'value')).toBe(false);
+    });
+
+    it('returns true when the value is null or undefined', () => {
+      expect(validateStoryArgs('key', null)).toBe(true);
+      expect(validateStoryArgs('key', undefined)).toBe(true);
+    });
+
+    it('returns true when the value is a date instance', () => {
+      expect(validateStoryArgs('key', new Date())).toBe(true);
+    });
+
+    it('returns true when the value is a number or boolean', () => {
+      expect(validateStoryArgs('key', 34.5)).toBe(true);
+      expect(validateStoryArgs('key', 123_456)).toBe(true);
+      expect(validateStoryArgs('key', false)).toBe(true);
+    });
+
+    it('returns true or false for valid string values', () => {
+      expect(validateStoryArgs('key', '_some_ string-value')).toBe(true);
+      expect(validateStoryArgs('key', '<special %chars &not *valid"')).toBe(false);
+    });
+
+    it('returns true or false for valid items in an array or object', () => {
+      expect(validateStoryArgs('key', [1, '2', false, null])).toBe(true);
+      expect(validateStoryArgs('key', [1, '%', true, null])).toBe(false);
+      expect(validateStoryArgs('key', { a: '1', b: undefined })).toBe(true);
+      expect(validateStoryArgs('key', { a: '@', b: undefined })).toBe(false);
+    });
+
+    it('returns false when unrecognized', () => {
+      expect(validateStoryArgs('key', () => {})).toBe(false);
+    });
+  });
+
+  describe('encodeStoryArgs', () => {
+    it('encodes null and undefined values', () => {
+      expect(encodeStoryArgs(null)).toBe('!null');
+      expect(encodeStoryArgs(undefined)).toBe('!undefined');
+    });
+
+    it('encodes date values', () => {
+      expect(encodeStoryArgs(new Date('2022-01-01T00:00Z')))
+        .toBe('!date(2022-01-01T00:00:00.000Z)');
+    });
+
+    it('encodes short and long hex colors with or without alpha values', () => {
+      expect(encodeStoryArgs('#012')).toBe('!hex(012)');
+      expect(encodeStoryArgs('#abcd')).toBe('!hex(abcd)');
+      expect(encodeStoryArgs('#012345')).toBe('!hex(012345)');
+      expect(encodeStoryArgs('#6789abcd')).toBe('!hex(6789abcd)');
+    });
+
+    it('encodes rgb and hsl colors with or without alpha values', () => {
+      expect(encodeStoryArgs('rgb(10, 20, 30)')).toBe('!rgb(10,20,30)');
+      expect(encodeStoryArgs('rgba(10, 20, 30, 0.2)')).toBe('!rgba(10,20,30,0.2)');
+      expect(encodeStoryArgs('hsl(120, 80%, 40%)')).toBe('!hsl(120,80,40)');
+      expect(encodeStoryArgs('hsla(120, 80%, 40%, 0.5)')).toBe('!hsla(120,80,40,0.5)');
+    });
+
+    it('encodes values within arrays and objects', () => {
+      expect(encodeStoryArgs([null, undefined, new Date('2022-01-01T00:00Z')]))
+        .toEqual(['!null', '!undefined', '!date(2022-01-01T00:00:00.000Z)']);
+      expect(encodeStoryArgs({ hex: '#f60', col: 'rgb(100, 0, 200)' }))
+        .toEqual({ hex: '!hex(f60)', col: '!rgb(100,0,200)' });
+    });
+
+    it('does not encode unrecognized values', () => {
+      expect(encodeStoryArgs(true)).toBe(true);
+      expect(encodeStoryArgs(false)).toBe(false);
+      expect(encodeStoryArgs(123_456)).toBe(123_456);
+      expect(encodeStoryArgs('string')).toBe('string');
+      // normally fail validation, but here to test they don't get accidentally encoded
+      expect(encodeStoryArgs('#notahex')).toBe('#notahex');
+      expect(encodeStoryArgs('rgb(1500)')).toBe('rgb(1500)');
+    });
+  });
+
+  describe('decodeStoryArgs', () => {
+    it('reverses encoding for most values', () => {
+      let test = { test: [null, undefined, new Date(), '#6cf', true, 123_456, 'string'] };
+      expect(decodeStoryArgs(encodeStoryArgs(test))).toEqual(test);
+    });
+
+    it('reconstructs rgb and hsl colors from encoded values', () => {
+      expect(decodeStoryArgs('!rgb(20,40,60)')).toBe('rgb(20, 40, 60)');
+      expect(decodeStoryArgs('!hsla(240,60,30,0.8)')).toBe('hsla(240, 60%, 30%, 0.8)');
+    });
+
+    it('decodes numbers from strings', () => {
+      expect(decodeStoryArgs('67.89')).toBe(67.89);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,42 +1441,42 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@percy/cli-command@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.3.tgz#e209cd4410cd8b6a0e130f48258173080bcdce96"
-  integrity sha512-WHICKTVdLW8vFm0emBkR/tV14XKWUfUEKw9UieSuEwIrQmMTPEaY0GxuRk3NrBMj6vkRuJW6yeLCGLVWFlRGlQ==
+"@percy/cli-command@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.4.tgz#828cc900717aa53c62d65349ce656285b9c4c8b2"
+  integrity sha512-is7ZFk1GbBajP3c16Pm+QBIyYE7371s5Os8VuTr4vyGOyYtR9s2wKS1EPzoUhKOZRDlJ1fAi4/PQQiZVZqd2IA==
   dependencies:
-    "@percy/config" "1.6.3"
-    "@percy/core" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/config" "1.6.4"
+    "@percy/core" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/client@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.3.tgz#7d75af3b92e3548fae70239cc16e4a832ae520e6"
-  integrity sha512-/gsfhikO3O36vWHH6TQ4QSVp/i1GkTt7lyPEn51jzKjV9rdQ8hmvxzMk2mleyYDAlZQBwyQaOZdMnhfbphLM2w==
+"@percy/client@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.4.tgz#ac7fd6c98144661574dc028587935570c706a7d3"
+  integrity sha512-LbJg/xhrXavHx4ZiijpAq5fpELKszePF0kGMvBHFeEorVjqTPmkZQg1pQW480ND+F/h6sLk15ucU0Aylp2eooA==
   dependencies:
-    "@percy/env" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/env" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/config@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.3.tgz#381e2b1f64593b651c90aeca911979cae5867f3f"
-  integrity sha512-BKDykqRoBrjeUHhfYLuTrAnxFYTuOXHc6XKmHuui44buoF5ZaG/2Md5DQpqfGVQ0Jdzumoge/up7PGmxdve1SQ==
+"@percy/config@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.4.tgz#31812d1f949f22f6589e87027716d29271822e67"
+  integrity sha512-e9e6CneEs2nmY3kstr5SNaoXT7LRk3Ga/noioSA5HNWPMqKPRwZaMlYLWA0NMSCbVcShMAqbRpa4FEbYTbpGGw==
   dependencies:
-    "@percy/logger" "1.6.3"
+    "@percy/logger" "1.6.4"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.3.tgz#a22c12e09d1e43aa6e72494ce94acae7beb8923d"
-  integrity sha512-RwRh8UUARv2gtD32C0NNe6VbBAWhne6IUBN5nMJ2yw6Q7LZqf2oa8kiocxGlyXpMTjYDRZ/FbNT0PqFw5o52gw==
+"@percy/core@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.4.tgz#8dc8b78e175b7312ab00ce05043f2b2d07861e09"
+  integrity sha512-p5XP8gcKqeozcJSPZS9ynVfuGV2rM9dYPCjL0GX7KRkjY9vpAO6IfDAFUbcJYbbwy54WiJqFjDMmm8xmTsVniQ==
   dependencies:
-    "@percy/client" "1.6.3"
-    "@percy/config" "1.6.3"
-    "@percy/dom" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/client" "1.6.4"
+    "@percy/config" "1.6.4"
+    "@percy/dom" "1.6.4"
+    "@percy/logger" "1.6.4"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -1487,20 +1487,20 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.3.tgz#cd2bf2569ba328f886ba9e026498a060fd980ffc"
-  integrity sha512-V4D/og0AOI1uFb5xtRYuypjmG6PuVwe+eMz10hFThRsxCiRGKlS7QnZUyNQkRwIO/k2r7LnboBpIUzBakSCgzA==
+"@percy/dom@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.4.tgz#3a823b2138055ac4a0804d8802e849282adbebd7"
+  integrity sha512-1Ox++5ZpbleaERifm+NTgSgSWKpAFSIxd5x4ZUI6HzNlojDverat6nIFjU+q5Y4Y2DHXn5ihagvODqspOq0Dkw==
 
-"@percy/env@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.3.tgz#ab9ff1f3cd85d77be409206d6469fa580efe5164"
-  integrity sha512-YsGQa6i/8Ca+XblRFxAClIo18dEYrU/rZKTZEio4WJ59zjoTskOU3VTgH4a4LX7J3LRpy0+A3v8UiUI4y3Vf8g==
+"@percy/env@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.4.tgz#80cb8dd2b44cdce3318cdde752fc183a1553ffa5"
+  integrity sha512-zn/RqbxSOtSnV8rApLtJ7EVzFdPVv+Agwq85/UuTK+2Md5Eb+mnT6TbmkRg/0n7l8d14uiDcRRwRi1+msVefZg==
 
-"@percy/logger@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.3.tgz#c13c64c20f9f842fe36266abbddfe9f07cfd2b6a"
-  integrity sha512-900DQ6KmDZVADuVdPARpZHvodALrswLOd/z4x2du484o/hyiNtO2nvO3rzyTCPVI+nreMT82yCy3JqnNwtJaSQ==
+"@percy/logger@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.4.tgz#598f1a5de0af9f8e3616a9d12ebf6fedbed5da78"
+  integrity sha512-lFPlVcxRtQyFw+TGzfOgFm4Vc/e8xx3nrrdKopnm22JIiTGH/hYFmq4A9u0e4b6Sp2nDZzWT2W5fxVHZiKDDlg==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.7"
@@ -2026,7 +2026,7 @@
     util-deprecate "^1.0.2"
     webpack ">=4.43.0 <6.0.0"
 
-"@storybook/router@6.5.9", "@storybook/router@^6.5.0":
+"@storybook/router@6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.5.9.tgz#4740248f8517425b2056273fb366ace8a17c65e8"
   integrity sha512-G2Xp/2r8vU2O34eelE+G5VbEEVFDeHcCURrVJEROh6dq2asFJAPbzslVXSeCqgOTNLSpRDJ2NcN5BckkNqmqJg==
@@ -8202,6 +8202,13 @@ qs@^6.10.0:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
## What is this?

We need to be able to recreate acceptable Storybook query params for args and globals when generating a story's URL. To do this, we have historically relied on Storybook's own internal utils to ensure 1:1 compatibility.

Unfortunately, this dependency has proven to be highly volatile. Early minor updates had the util moving between files, while other updates effected the package's build output. Most recently, The package's distributed files have become tightly bundled to React. While this doesn't present a problem when used within a React Storybook project, it does however cause dependency errors when used outside of React environments (even when the target Storybook is using React).

With these changes, we no longer depend on a Storybook internal package, and instead reimplement and recreate Storybook URL params as closely as possible. The encode/decode functions introduced here were copied and adapted from Storybook's internal util to fit our own coding style. I suspect (and hope) that future updates will only require adding additional features rather than changing existing encoding/decoding behavior.

While making these changes, I realized that certain values were being lost between the transfer from the browser execution context to Node's execution context. To preserve these values, all args and globals are now serialized and encoded before being transferred to the Node context. This is done by providing page eval scripts with additional Storybook specific helper functions. Any args and globals specified within a Percy config file are also encoded separately to ensure uniformity when building each story snapshot's URL.

An additional story snapshot was added as well as several unit tests to add coverage for the new appropriated Storybook params utils. Some error reporting was also adjusted to ease debugging.