### PR TITLE
🐛 Fix capture options validation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "^1.7.2",
+    "@percy/cli-command": "^1.8.0",
     "cross-spawn": "^7.0.3",
     "qs": "^6.11.0"
   },

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -206,6 +206,8 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
           options.domSnapshot = (yield page.snapshot(options)).dom;
         }
 
+        // validate without logging to prune all other options
+        PercyConfig.validate(options, '/snapshot/dom');
         // snapshots are queued and do not need to be awaited on
         percy.snapshot(options);
         // discard this story snapshot when done

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -341,7 +341,8 @@ describe('percy storybook', () => {
       '    - include: /two/i',
       '      suffix: " (2)"',
       '      args: { invalid: "!@#$%" }',
-      '      globals: { invalid: "^&*()" }'
+      '      globals: { invalid: "^&*()" }',
+      '      waitForSelector: .foo-bar'
     ].join('\n'));
 
     await storybook(['http://localhost:9000', '--dry-run', '--include=Options: Invalid']);

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -362,6 +362,39 @@ describe('percy storybook', () => {
     ]));
   });
 
+  it('warns when using capture options with javascript enabled', async () => {
+    fs.writeFileSync('.percy.yml', [
+      'version: 2',
+      'snapshot:',
+      '  enableJavaScript: true',
+      'storybook:',
+      '  waitForSelector: "#root"',
+      '  additionalSnapshots:',
+      '    - include: Skip',
+      '      suffix: " (Invalid Wait)"',
+      '      waitForSelector: "body"',
+      '    - include: Skip',
+      '      suffix: " (Valid Wait)"',
+      '      enableJavaScript: false',
+      '      waitForSelector: "body"'
+    ].join('\n'));
+
+    await storybook(['http://localhost:9000']);
+
+    expect(logger.stderr).toEqual([
+      '[percy] Invalid config:',
+      '[percy] - storybook.waitForSelector: not used with JavaScript enabled',
+      '[percy] - storybook.additionalSnapshots[0].waitForSelector: not used with JavaScript enabled'
+    ]);
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Snapshot taken: Snapshot: First',
+      '[percy] Snapshot taken: Snapshot: Second',
+      '[percy] Snapshot taken: Skip: But Not Me',
+      '[percy] Snapshot taken: Skip: But Not Me (Invalid Wait)',
+      '[percy] Snapshot taken: Skip: But Not Me (Valid Wait)'
+    ]));
+  });
+
   it('appends custom args, globals, and query params to story urls', async () => {
     await storybook(['http://localhost:9000', '--dry-run', '--verbose', '--include=/params/']);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,42 +1477,42 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@percy/cli-command@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.7.2.tgz#93b4fab4a01b89bad5bda53bf1ea360d426a08d4"
-  integrity sha512-roTWulBAidSX1ypH23FjVGnCX32YMsb6wUf3EFGNxnEdKYnMsOaH0zvDImJY6izz4NbP+XZ9HfGXu1oVPftoUw==
+"@percy/cli-command@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.8.0.tgz#44dc5c229e5d15b2990d13f4a8a086979684e160"
+  integrity sha512-cA/qJL8ZcICZPngqfzaSey9u3ys0y+rz/iTtDwLvFk8W+h6AGcYzGL44VJtdOCT8KBrsU4qpYWiykZegROWQvw==
   dependencies:
-    "@percy/config" "1.7.2"
-    "@percy/core" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/config" "1.8.0"
+    "@percy/core" "1.8.0"
+    "@percy/logger" "1.8.0"
 
-"@percy/client@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.7.2.tgz#124604c40e3b16c79f0a243a62f1f27d1ab37ab3"
-  integrity sha512-GjEp3m+WXO2S0iLGwKZs+6zDFkP/V5XJICeou6Q1pOb8N1E3ZhyFfm3+gS2qMwVuf6xIWgxO+RXZxIs2JVJrJw==
+"@percy/client@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.8.0.tgz#b56206432d5f6d4ee71877f1f277e11178951587"
+  integrity sha512-PMkST2X57m9paTZ22yv8yNeO2X33FeDTnEo99r4TKriiIs5Vm4UKurKYJdztS8OrYh/xl7tx1ATpc6n3vvNkEg==
   dependencies:
-    "@percy/env" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/env" "1.8.0"
+    "@percy/logger" "1.8.0"
 
-"@percy/config@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.7.2.tgz#c087bd9dd35c81372b03b51360b91fd2cfd58428"
-  integrity sha512-omING0fj92NG6XVScclkg8l82QUdPw+4YKJjUOHQVqOqyq+7H9A45KtlOk9LVStbVenzRiqH7C+9NhYa+a+/Vg==
+"@percy/config@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.8.0.tgz#f0aaff8b04e5b6e3809ba9f41177027ddc4b3db1"
+  integrity sha512-B4cfcNpwqMKKC2US9k+y3sfsgD9JcspNDT+VNPA+9zp1PEbyW5dDe3FQY5bjoLRtQHcNtepBOTMurmWVhjViWw==
   dependencies:
-    "@percy/logger" "1.7.2"
+    "@percy/logger" "1.8.0"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.7.2.tgz#95551573a623355e47b026645d1258f75cad8acf"
-  integrity sha512-TsHQbsGtpzEW6bo+BIRkNoIFZrjrWHb9B2pXoMRnG61m6F6KtoL1yOuHhorhrHkCtCtX3A7KXfJtcO9E1oN9RQ==
+"@percy/core@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.8.0.tgz#a8ce0be3edf7c10dfb6d71825ddaba3b20aaa340"
+  integrity sha512-v6kyC89iXYCWPuuG0XGtBKXVRc92/xZxKZQiehNC6I2/svCAW3GPWWQro8R+HX5ZUqVY6uqPHNdt2oJNKAEJNg==
   dependencies:
-    "@percy/client" "1.7.2"
-    "@percy/config" "1.7.2"
-    "@percy/dom" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/client" "1.8.0"
+    "@percy/config" "1.8.0"
+    "@percy/dom" "1.8.0"
+    "@percy/logger" "1.8.0"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -1523,20 +1523,20 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.7.2.tgz#df12f2d6cd2389a01acd8354fac8496dbbf1e50f"
-  integrity sha512-ipi7SF4nS+/UfHXYLeJTRp25rGvZhRwmGQv6WjAK1HGkl4OJaFJNPbWe0+SCG4zwSsCudeY4lxk5rk05Ev6b1A==
+"@percy/dom@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.8.0.tgz#6bd4bc72fd71c6fd445f2a223d5f860af9b36183"
+  integrity sha512-Q/a5uq3h7xUOZoFEYGhYxaNv6N/wxnQi9K3oaMfa1I8JvBqEVKzuw4izY5Q0OsOmiz78JJFmsLn8IbLh9NuP2w==
 
-"@percy/env@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.7.2.tgz#99fd35eeabedcf3762af2efbba177c7bbc57309a"
-  integrity sha512-exnZsBROCg17bNHqF7CEJVheGVnysZlChSiJHssLcdPGjg2+decefc26UZLA4PuEqgcmYWun5WyGLRPQo62oUQ==
+"@percy/env@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.8.0.tgz#a3c3fa9cb071df0f94b7c197b9235aaf4e62a747"
+  integrity sha512-njfRWRrmyGVOWo1U+Zd8tyniOiNVYWvQvyodHWzqz7AoNz0Zr/+sCs8TsuMfF9QAb3MLcWn4LJoZE09mBIFBwg==
 
-"@percy/logger@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.7.2.tgz#38b008459f5598d3a8f8708dc68a246473aac8a8"
-  integrity sha512-GSbOqPpjM+UC/0pcm6oTi+KI4u/nbs8Awz0HtFcoxyaNRBptRFUh75zF7qI0zB/HRp8QlZ0z4DayCepfrqqO0A==
+"@percy/logger@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.8.0.tgz#e85f60dff1b118644f91f6d73c08a455169f57af"
+  integrity sha512-z1PNQFXDr4+y+a6FPzsZBuMttr0VrRpYSpxRhvhTZTjnLsBvgQ6VP2GxyFlp7E3Y4aG9Lmzau71s2Nlb35Ylgg==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
## What is this?

This PR fixes #621 by utilizing validation helpers to scrub unused snapshot options without warning about them. A test was adjusted slightly to ensure the warnings are no longer logged when capture options such as `waitForSelector` are provided.

While making this change, I realized that these capture options are not actually used at all when JavaScript is enabled. This is intended since enabling JavaScript tells this SDK to use the raw preview DOM to avoid rehydration issues. But it may be confusing if some people expect these options to work when they won't be used at all. 

To address this confusion, the config schema was refactored to validate against capture options when JavaScript is enabled. This required a couple small upstream changes and a much more complex schema for this SDK. The result is when JavaScript is enabled in for a snapshot (via a config file, storybook parameters, snapshot options, etc), capture options are validated against to warn that they are not used with JavaScript enabled.