### PR TITLE
✨  Skip story on error and move to next stories

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -188,6 +188,14 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
     // set storybook environment info
     percy.client.addEnvironmentInfo(environmentInfo);
 
+    // We use an outer and inner loop on same snapshots.length
+    // - we create a new page and load one story on it at a time for snapshotting
+    // - if it throws exception then we want to catch it outside of `withPage` call as
+    //   when `withPage` returns it closes the page
+    // - we want to make sure we close the page that had exception in story to make sure
+    //   we dont reuse a page which is possibly in a weird state due to last exception
+    // - so post exception we come out of inner loop and skip the story, create new page
+    //   using outer loop and continue next stories again on a new page
     while (snapshots.length) {
       try {
         // use a single page to capture story snapshots without reloading

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -225,17 +225,15 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
           return lastCount > snapshots.length;
         });
       } catch (e) {
-        // if we get an exception while capturing a story
-        // - we want to print error
-        // - skip story
-        // - continue capturing stories on a new page to avoid weird page states
-        let { name } = snapshots[0];
-
-        log.error(`Failed to capture story: ${name}`);
-        log.error(e);
-
-        // ignore story
-        snapshots.shift();
+        if (process.env.PERCY_SKIP_STORY_ON_ERROR === 'true') {
+          let { name } = snapshots[0];
+          log.error(`Failed to capture story: ${name}`);
+          log.error(e);
+          // ignore story
+          snapshots.shift();
+        } else {
+          throw e;
+        }
       }
     }
 

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -188,38 +188,56 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
     // set storybook environment info
     percy.client.addEnvironmentInfo(environmentInfo);
 
-    // use a single page to capture story snapshots without reloading
-    yield* withPage(percy, previewUrl, async function*(page) {
-      // determines when to retry page crashes
-      lastCount = snapshots.length;
+    while (snapshots.length) {
+      try {
+        // use a single page to capture story snapshots without reloading
+        yield* withPage(percy, previewUrl, async function*(page) {
+          // determines when to retry page crashes
+          lastCount = snapshots.length;
 
-      while (snapshots.length) {
-        // separate story and snapshot options
-        let { id, args, globals, queryParams, ...options } = snapshots[0];
+          while (snapshots.length) {
+            // separate story and snapshot options
+            let { id, args, globals, queryParams, ...options } = snapshots[0];
 
-        if (flags.dryRun || options.enableJavaScript || percy.config.snapshot.enableJavaScript) {
-          // when dry-running or when javascript is enabled, use the preview dom
-          options.domSnapshot = previewResource.content;
-        } else {
-          // when not dry-running and javascript is not enabled, capture the story dom
-          yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
-          /* istanbul ignore next: tested, but coverage is stripped */
-          let { dom, domSnapshot = dom } = yield page.snapshot(options);
-          options.domSnapshot = domSnapshot;
-        }
+            if (flags.dryRun || options.enableJavaScript || percy.config.snapshot.enableJavaScript) {
+              log.debug(`Loading story via previewResource: ${options.name}`);
+              // when dry-running or when javascript is enabled, use the preview dom
+              options.domSnapshot = previewResource.content;
+            } else {
+              log.debug(`Loading story: ${options.name}`);
+              // when not dry-running and javascript is not enabled, capture the story dom
+              yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
+              /* istanbul ignore next: tested, but coverage is stripped */
+              let { dom, domSnapshot = dom } = yield page.snapshot(options);
+              options.domSnapshot = domSnapshot;
+            }
 
-        // validate without logging to prune all other options
-        PercyConfig.validate(options, '/snapshot/dom');
-        // snapshots are queued and do not need to be awaited on
-        percy.snapshot(options);
-        // discard this story snapshot when done
+            // validate without logging to prune all other options
+            PercyConfig.validate(options, '/snapshot/dom');
+            // snapshots are queued and do not need to be awaited on
+            percy.snapshot(options);
+            // discard this story snapshot when done
+            snapshots.shift();
+          }
+        }, () => {
+          log.debug(`Page crashed while loading story: ${snapshots[0].name}`);
+          // return true to retry as long as the length decreases
+          return lastCount > snapshots.length;
+        });
+      } catch (e) {
+        // if we get an exception while capturing a story
+        // - we want to print error
+        // - skip story
+        // - continue capturing stories on a new page to avoid weird page states
+        let { name } = snapshots[0];
+
+        log.error(`Failed to capture story: ${name}`);
+        log.error(e);
+
+        // ignore story
         snapshots.shift();
       }
-    }, () => {
-      log.debug(`Page crashed while loading story: ${snapshots[0].name}`);
-      // return true to retry as long as the length decreases
-      return lastCount > snapshots.length;
-    });
+    }
 
     // will stop once snapshots are done processing
     yield* percy.yield.stop();

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -181,7 +181,9 @@ describe('percy storybook', () => {
       expect(logger.stderr).toEqual([
         '[percy] Failed to capture story: foo: bar',
         // error logs contain the client stack trace
-        jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s)
+        jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s),
+        // does not create a build if all stories failed [ 1 in this case ]
+        '[percy] Build not created'
       ]);
     });
   });


### PR DESCRIPTION
Context:
- Currently if percySnapshot fails on one of the stories [ say dom.js returned an exception or timedout ] we throw that error again
- This breaks test suite and no further stories are uploaded

Change:
- We add an env var `PERCY_SKIP_STORY_ON_ERROR` which if set to 'true' would log the error skip the story and move to next story 
- We also recreate the page to avoid any state related issues