### PR TITLE
🐛 ✨Fix eval setCurrentStory error + make logging better

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -199,7 +199,9 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
     while (snapshots.length) {
       try {
         // use a single page to capture story snapshots without reloading
-        yield* withPage(percy, previewUrl, async function*(page) {
+        // loading an existing story instead of just iframe.html as that triggers `storyMissing` event
+        // This in turn leads to promise rejection and failure
+        yield* withPage(percy, `${previewUrl}?id=${snapshots[0].id}&viewMode=story`, async function*(page) {
           // determines when to retry page crashes
           lastCount = snapshots.length;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,7 +142,7 @@ export async function* withPage(percy, url, callback, retry) {
     return yield* yieldTo(callback(page));
   } catch (error) {
     // if the page crashed and retry returns truthy, try again
-    if (error?.message?.includes('crashed') && retry?.()) {
+    if (error.message?.includes('crashed') && retry?.()) {
       return yield* withPage(...arguments);
     }
 
@@ -247,9 +247,9 @@ export function evalSetCurrentStory({ waitFor }, story) {
     // resolve when rendered, reject on any other renderer event
     return new Promise((resolve, reject) => {
       channel.on('storyRendered', resolve);
-      channel.on('storyMissing', reject);
-      channel.on('storyErrored', reject);
-      channel.on('storyThrewException', reject);
+      channel.on('storyMissing', () => reject('Story Missing'));
+      channel.on('storyErrored', () => reject('Story Errored'));
+      channel.on('storyThrewException', () => reject('Story Threw Exception'));
     });
   });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -247,9 +247,9 @@ export function evalSetCurrentStory({ waitFor }, story) {
     // resolve when rendered, reject on any other renderer event
     return new Promise((resolve, reject) => {
       channel.on('storyRendered', resolve);
-      channel.on('storyMissing', () => reject(new Error('Story Missing')));
-      channel.on('storyErrored', () => reject(new Error('Story Errored')));
-      channel.on('storyThrewException', () => reject(new Error('Story Threw Exception')));
+      channel.on('storyMissing', (err) => reject(err || new Error('Story Missing')));
+      channel.on('storyErrored', (err) => reject(err || new Error('Story Errored')));
+      channel.on('storyThrewException', (err) => reject(err || new Error('Story Threw Exception')));
     });
   });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -247,9 +247,9 @@ export function evalSetCurrentStory({ waitFor }, story) {
     // resolve when rendered, reject on any other renderer event
     return new Promise((resolve, reject) => {
       channel.on('storyRendered', resolve);
-      channel.on('storyMissing', () => reject('Story Missing'));
-      channel.on('storyErrored', () => reject('Story Errored'));
-      channel.on('storyThrewException', () => reject('Story Threw Exception'));
+      channel.on('storyMissing', () => reject(new Error('Story Missing')));
+      channel.on('storyErrored', () => reject(new Error('Story Errored')));
+      channel.on('storyThrewException', () => reject(new Error('Story Threw Exception')));
     });
   });
 }

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -156,12 +156,12 @@ describe('percy storybook', () => {
 
     await expectAsync(storybook(['http://localhost:8000']))
     // message contains the client stack trace
-      .toBeRejectedWithError(/^Story Errored\n.*\/iframe\.html.*$/s);
+      .toBeRejectedWithError(/^Story Error\n.*\/iframe\.html.*$/s);
 
     expect(logger.stderr).toEqual([
       '[percy] Build not created',
       // message contains the client stack trace
-      jasmine.stringMatching(/^\[percy\] Error: Story Errored\n.*\/iframe\.html.*$/s)
+      jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s)
     ]);
   });
 
@@ -191,7 +191,7 @@ describe('percy storybook', () => {
       expect(logger.stderr).toEqual([
         '[percy] Failed to capture story: foo: bar',
         // error logs contain the client stack trace
-        jasmine.stringMatching(/^\[percy\] Error: Story Errored\n.*\/iframe\.html.*$/s),
+        jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s),
         // does not create a build if all stories failed [ 1 in this case ]
         '[percy] Build not created'
       ]);

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -156,12 +156,12 @@ describe('percy storybook', () => {
 
     await expectAsync(storybook(['http://localhost:8000']))
     // message contains the client stack trace
-      .toBeRejectedWithError(/^Story Error\n.*\/iframe\.html.*$/s);
+      .toBeRejectedWithError(/^Story Errored\n.*\/iframe\.html.*$/s);
 
     expect(logger.stderr).toEqual([
       '[percy] Build not created',
       // message contains the client stack trace
-      jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s)
+      jasmine.stringMatching(/^\[percy\] Error: Story Errored\n.*\/iframe\.html.*$/s)
     ]);
   });
 
@@ -191,7 +191,7 @@ describe('percy storybook', () => {
       expect(logger.stderr).toEqual([
         '[percy] Failed to capture story: foo: bar',
         // error logs contain the client stack trace
-        jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s),
+        jasmine.stringMatching(/^\[percy\] Error: Story Errored\n.*\/iframe\.html.*$/s),
         // does not create a build if all stories failed [ 1 in this case ]
         '[percy] Build not created'
       ]);


### PR DESCRIPTION
**Description-**
- [x] Fixed logging, earler we were just doing `reject()` without passing any error, hence it was passed as `undefined` and hence error was `undefined` and we were unable to parse `message` from it
- [x] Fixed issue where loading `iframe.html` as base preview URL would trigger the `storyMissing` event which would call `reject` and break flow. Solution for this was to open first component, instead of `/iframe.html`