### PR TITLE
feat: add captureServiceWorker flag when opening browser

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -116,7 +116,7 @@ export async function* withPage(percy, url, callback, retry) {
   let page = yield percy.browser.page({
     networkIdleTimeout: percy.config.discovery.networkIdleTimeout,
     requestHeaders: getAuthHeaders(percy.config.discovery),
-    captureMockedServiceWorker: percy.config.captureMockedServiceWorker,
+    captureMockedServiceWorker: percy.config.discovery.captureMockedServiceWorker,
     userAgent: percy.config.discovery.userAgent
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,6 +116,7 @@ export async function* withPage(percy, url, callback, retry) {
   let page = yield percy.browser.page({
     networkIdleTimeout: percy.config.discovery.networkIdleTimeout,
     requestHeaders: getAuthHeaders(percy.config.discovery),
+    captureServiceWorker: percy.config.captureServiceWorker,
     userAgent: percy.config.discovery.userAgent
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,7 +116,7 @@ export async function* withPage(percy, url, callback, retry) {
   let page = yield percy.browser.page({
     networkIdleTimeout: percy.config.discovery.networkIdleTimeout,
     requestHeaders: getAuthHeaders(percy.config.discovery),
-    captureServiceWorker: percy.config.captureServiceWorker,
+    captureMockedServiceWorker: percy.config.captureMockedServiceWorker,
     userAgent: percy.config.discovery.userAgent
   });
 


### PR DESCRIPTION
**context -**
- we have added support for capturing service worker intercepted requests in https://github.com/percy/cli/pull/1443
- in msw, it checks if service worker controller is registered or not. If it is not registered then it goes into an infinite rendering loop.
- when using percy browser, by default we have `setByPassServiceWorker: false` which does not allow registration of service worker controller and hence we go in infinite rendering loop.
- adding `captureServiceWorker: true` enables us to register service worker controller, and hence resolves the infinite rendering loop.