### PR TITLE
Add Storybook 8 compatibility

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -200,12 +200,14 @@ export function evalStorybookStorySnapshots({ waitFor }) {
 
   return waitFor(async () => {
     // uncache stories, if cached via storyStorev7: true
-    await (window.__STORYBOOK_PREVIEW__?.cacheAllCSFFiles?.() ||
+    await (window.__STORYBOOK_PREVIEW__?.ready?.() ||
+      window.__STORYBOOK_PREVIEW__?.cacheAllCSFFiles?.() ||
       window.__STORYBOOK_STORY_STORE__?.cacheAllCSFFiles?.());
     // use newer storybook APIs before old APIs
     await (window.__STORYBOOK_PREVIEW__?.extract?.() ||
            window.__STORYBOOK_STORY_STORE__?.extract?.());
-    return window.__STORYBOOK_STORY_STORE__.raw();
+    return await window.__STORYBOOK_PREVIEW__?.extract?.().then(data => Object.values(data)) ||
+      window.__STORYBOOK_STORY_STORE__.raw();
   }, 5000).catch(() => Promise.reject(new Error(
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'


### PR DESCRIPTION
Hello,

I faced [this issue](https://github.com/percy/percy-storybook/issues/911), which seems to be related to [this part of the migration](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#storystore-and-methods-deprecated).
I made this change and tried it locally. It worked.
It should be better to add the [dependabot PR to upgrade to Storybook 8](https://github.com/percy/percy-storybook/pull/908), but the node version in tests should be changed to 18+.
Additionnaly, I was unable to run the tests due to download failure (maybe related to my company's security policy) :

> ✗ snapshots live urls
      - Error: Download failed: 404 - https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/929475/chrome-mac.zip

There are definitely a lot more things that need to change to fully handle v8, but this seems like a good start.