### PR TITLE
Add retry in withPage function

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -232,7 +232,7 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
           log.debug(`Page crashed while loading story: ${snapshots[0].name}`);
           // return true to retry as long as the length decreases
           return lastCount > snapshots.length;
-        });
+        }, { snapshotName: snapshots[0].name });
       } catch (e) {
         if (process.env.PERCY_SKIP_STORY_ON_ERROR === 'true') {
           let { name } = snapshots[0];

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,7 +139,7 @@ export function decodeStoryArgs(value) {
 
 // Borrows a percy discovery browser page to navigate to a URL and evaluate a function, returning
 // the results and normalizing any thrown errors.
-export async function* withPage(percy, url, callback, retry) {
+export async function* withPage(percy, url, callback, retry, args) {
   let log = logger('storybook:utils');
   let attempt = 0;
   let retries = 3;
@@ -195,9 +195,9 @@ export async function* withPage(percy, url, callback, retry) {
       attempt++;
       let shouldRetry = process.env.ENABLE_RETRY === 'true';
       if (!shouldRetry || attempt === retries) {
-          throw error;
+        throw error;
       }
-      log.warn(`Retrying Story: ${args.snapshotName}`)
+      log.warn(`Retrying Story: ${args.snapshotName}`);
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -193,8 +193,8 @@ export async function* withPage(percy, url, callback, retry, args) {
       }
     } catch (error) {
       attempt++;
-      let shouldRetry = process.env.ENABLE_RETRY === 'true';
-      if (!shouldRetry || attempt === retries) {
+      let enableRetry = process.env.PERCY_RETRY_STORY_ON_ERROR || 'true';
+      if (!(enableRetry === 'true') || attempt === retries) {
         throw error;
       }
       log.warn(`Retrying Story: ${args.snapshotName}`);

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -107,6 +107,7 @@ describe('percy storybook', () => {
   });
 
   it('errors when the client api is missing', async () => {
+    process.env.PERCY_RETRY_STORY_ON_ERROR = false;
     await expectAsync(storybook(['http://localhost:8000'])).toBeRejected();
 
     expect(logger.stderr).toEqual([
@@ -147,6 +148,7 @@ describe('percy storybook', () => {
   });
 
   it('errors when the storybook page errors', async () => {
+    process.env.PERCY_RETRY_STORY_ON_ERROR = false;
     server.reply('/iframe.html', () => [200, 'text/html', [
       `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
         { id: '1', kind: 'foo', name: 'bar' }
@@ -183,10 +185,12 @@ describe('percy storybook', () => {
   describe('with PERCY_SKIP_STORY_ON_ERROR set to true', () => {
     beforeAll(() => {
       process.env.PERCY_SKIP_STORY_ON_ERROR = true;
+      process.env.PERCY_RETRY_STORY_ON_ERROR = false;
     });
 
     afterAll(() => {
       delete process.env.PERCY_SKIP_STORY_ON_ERROR;
+      delete process.env.PERCY_RETRY_STORY_ON_ERROR;
     });
 
     it('skips the story and logs the error but does not break build', async () => {
@@ -514,6 +518,7 @@ describe('percy storybook', () => {
   });
 
   it('handles page crashes while taking snapshots', async () => {
+    process.env.PERCY_RETRY_STORY_ON_ERROR = false;
     // eslint-disable-next-line import/no-extraneous-dependencies
     let { Percy } = await import('@percy/core');
 

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -193,7 +193,7 @@ describe('percy storybook', () => {
       delete process.env.PERCY_RETRY_STORY_ON_ERROR;
     });
 
-    it('retries story logs the error but does not break build if skip is enabled', async () => {
+    it('skips the story and logs the error but does not break build', async () => {
       server.reply('/iframe.html', () => [200, 'text/html', [
         `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
           { id: '1', kind: 'foo', name: 'bar' }
@@ -241,7 +241,7 @@ describe('percy storybook', () => {
       delete process.env.PERCY_RETRY_STORY_ON_ERROR;
     });
 
-    it('skips the story and logs the error but does not break build', async () => {
+    it('retries story logs the error but does not break build if skip is enabled', async () => {
       server.reply('/iframe.html', () => [200, 'text/html', [
         `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
           { id: '1', kind: 'foo', name: 'bar' }

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -221,8 +221,6 @@ describe('percy storybook', () => {
 
       // contains logs of story error
       expect(logger.stderr).toEqual([
-        '[percy] Retrying Story: foo: bar',
-        '[percy] Retrying Story: foo: bar',
         '[percy] Failed to capture story: foo: bar',
         // error logs contain the client stack trace
         jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s),
@@ -271,6 +269,8 @@ describe('percy storybook', () => {
 
       // contains logs of story error
       expect(logger.stderr).toEqual([
+        '[percy] Retrying Story: foo: bar',
+        '[percy] Retrying Story: foo: bar',
         '[percy] Failed to capture story: foo: bar',
         // error logs contain the client stack trace
         jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s),

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -193,6 +193,56 @@ describe('percy storybook', () => {
       delete process.env.PERCY_RETRY_STORY_ON_ERROR;
     });
 
+    it('retries story logs the error but does not break build if skip is enabled', async () => {
+      server.reply('/iframe.html', () => [200, 'text/html', [
+        `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
+          { id: '1', kind: 'foo', name: 'bar' }
+        ])} }, ${
+          'channel: { emit() {}, on: (a, c) => a === "storyErrored" && c(new Error("Story Error")) }'
+        } }</script>`,
+        `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
+          { id: '1', kind: 'foo', name: 'bar' }
+        ])} }</script>`
+      ].join('')]);
+
+      server.reply('/iframe.html?id=1&viewMode=story', () => [200, 'text/html', [
+        `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
+          { id: '1', kind: 'foo', name: 'bar' }
+        ])} }, ${
+          'channel: { emit() {}, on: (a, c) => a === "storyErrored" && c(new Error("Story Error")) }'
+        } }</script>`,
+        `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
+          { id: '1', kind: 'foo', name: 'bar' }
+        ])} }</script>`
+      ].join('')]);
+
+      // does not reject
+      await storybook(['http://localhost:8000']);
+
+      // contains logs of story error
+      expect(logger.stderr).toEqual([
+        '[percy] Retrying Story: foo: bar',
+        '[percy] Retrying Story: foo: bar',
+        '[percy] Failed to capture story: foo: bar',
+        // error logs contain the client stack trace
+        jasmine.stringMatching(/^\[percy\] Error: Story Error\n.*\/iframe\.html.*$/s),
+        // does not create a build if all stories failed [ 1 in this case ]
+        '[percy] Build not created'
+      ]);
+    });
+  });
+
+  describe('with PERCY_RETRY_STORY_ON_ERROR set to true', () => {
+    beforeAll(() => {
+      process.env.PERCY_SKIP_STORY_ON_ERROR = true;
+      process.env.PERCY_RETRY_STORY_ON_ERROR = true;
+    });
+
+    afterAll(() => {
+      delete process.env.PERCY_SKIP_STORY_ON_ERROR;
+      delete process.env.PERCY_RETRY_STORY_ON_ERROR;
+    });
+
     it('skips the story and logs the error but does not break build', async () => {
       server.reply('/iframe.html', () => [200, 'text/html', [
         `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([


### PR DESCRIPTION
- Adding retry in withPage function.
- Update evalSetCurrentStory swap:  `setCurrentStory` & `updateGlobals`.

Above changes are with respect to storybook v8 fixes, we were getting `execution context destroyed` on several stories. swapping above calls fixes this.