### PR TITLE
Change behaviour of enable JS to prioritise options passed

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -208,7 +208,8 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
             // separate story and snapshot options
             let { id, args, globals, queryParams, ...options } = snapshots[0];
 
-            if (flags.dryRun || options.enableJavaScript || percy.config.snapshot.enableJavaScript) {
+            const enableJavaScript = options.enableJavaScript ?? percy.config.snapshot.enableJavaScript;
+            if (flags.dryRun || enableJavaScript) {
               log.debug(`Loading story via previewResource: ${options.name}`);
               // when dry-running or when javascript is enabled, use the preview dom
               options.domSnapshot = previewResource.content;

--- a/test/.storybook/snapshot.stories.js
+++ b/test/.storybook/snapshot.stories.js
@@ -18,7 +18,8 @@ export const First = () => (
 
 First.parameters = {
   percy: {
-    domTransformation: '(documentElement) => { documentElement.querySelectorAll(".removeMe").forEach(ele => ele.remove()); }'
+    domTransformation: '(documentElement) => { documentElement.querySelectorAll(".removeMe").forEach(ele => ele.remove()); }',
+    enableJavascript: false // this should be priotised over global config
   }
 }
 export const Second = () => (

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -333,6 +333,24 @@ describe('percy storybook', () => {
     expect(callArgs[1][0].domSnapshot).toEqual(previewDOM);
   });
 
+  it('uses the preview dom when javascript is enabled', async () => {
+    fs.writeFileSync('.percy.yml', [
+      'version: 2',
+      'snapshot:',
+      '  enableJavaScript: true'
+    ].join('\n'));
+
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    let { Percy } = await import('@percy/core');
+    spyOn(Percy.prototype, 'snapshot').and.callThrough();
+
+    await storybook(['http://localhost:9000', '--include=First', '--verbose']);
+
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      '[percy:storybook] Loading story: Snapshot: First'
+    ]));
+  });
+
   it('removes element when domTransformation is passed', async () => {
     // eslint-disable-next-line import/no-extraneous-dependencies
     let { Percy } = await import('@percy/core');


### PR DESCRIPTION
Fixed behaviour of enable javascript where if percy.config.snapshot.enableJavascript is true and options.enableJavascript is false. sdk is going through enableJS flow. ideally it should use snapshot level option if passed over global options