### PR TITLE
Fixed to output error and retry messages with current snapshot name

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -233,7 +233,11 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
           log.debug(`Page crashed while loading story: ${snapshots[0].name}`);
           // return true to retry as long as the length decreases
           return lastCount > snapshots.length;
-        }, { snapshotName: snapshots[0].name });
+        }, {
+          get snapshotName() {
+            return snapshots[0].name;
+          },
+        });
       } catch (e) {
         if (process.env.PERCY_SKIP_STORY_ON_ERROR === 'true') {
           let { name } = snapshots[0];


### PR DESCRIPTION
Previously, the first snapshot name when `withPage` was execute was output, no matter which snapshot the error occurred.