### PR TITLE
📜 Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ percy storybook https://storybook.foobar.com
 Automatically run `start-storybook`:
 
 ``` sh
-$ percy storybook:start --port=9009 --static-dir=./public
+$ percy storybook:start --port=9009
 ```
 
 ## Commands:

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ Global options:
 Examples:
   $ percy storybook:start
   $ percy storybook:start --port 9000
-  $ percy storybook:start --static-dir public
 ```
 <!-- commandsstop -->
 

--- a/src/start.js
+++ b/src/start.js
@@ -20,8 +20,7 @@ export const start = command('start', {
 
   examples: [
     '$0',
-    '$0 --port 9000',
-    '$0 --static-dir public'
+    '$0 --port 9000'
   ],
 
   percy: {


### PR DESCRIPTION
This pull request updates the documentation and usage examples for the `percy storybook:start` command to remove references to the deprecated or unnecessary `--static-dir` option. The changes clarify how to use the command and ensure consistency between documentation and code.

**Documentation updates:**

* Removed the `--static-dir` option from the example command in the `README.md` to reflect current usage.
* Updated the list of example commands in the `README.md` to exclude the `--static-dir` example.

**Code updates:**

* Removed the `--static-dir` example from the `examples` array in `src/start.js` to match the updated documentation.