### PR TITLE
Fix: Preserve story state & prevent blank/loader snapshots after reload

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -16,7 +16,7 @@ import {
 } from './utils.js';
 
 // Main capture function
-export async function captureDOM(page, options, percy, log) {
+export async function captureDOM(page, options, percy, log, story) {
   const responsiveSnapshotCapture = isResponsiveSnapshotCaptureEnabled(
     options,
     percy.config
@@ -24,7 +24,7 @@ export async function captureDOM(page, options, percy, log) {
 
   if (responsiveSnapshotCapture) {
     log.debug('captureDOM: Using responsive snapshot capture', { options });
-    return await captureResponsiveDOM(page, options, percy, log);
+    return await captureResponsiveDOM(page, options, percy, log, story);
   }
 
   log.debug('captureDOM: Using single snapshot capture');
@@ -202,7 +202,7 @@ async function* processStory(page, story, previewResource, percy, flags, log) {
     log.debug(`Loading story: ${options.name}`);
     // when not dry-running and javascript is not enabled, capture the story dom
     yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
-    options.domSnapshot = await captureDOM(page, options, percy, log);
+    options.domSnapshot = await captureDOM(page, options, percy, log, story);
   }
 
   // validate without logging to prune all other options

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -58,7 +58,6 @@ describe('captureDOM behavior', () => {
         // Simulate the story state restoration behavior when PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE is set
         if (process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE && story) {
           log.debug('Reloading page for responsive capture');
-          log.debug('Re-applying story state after reload');
         }
 
         return uniqueWidths.map(width => ({
@@ -196,6 +195,7 @@ describe('captureDOM behavior', () => {
     await captureDOM(page, options, percy, log, null);
 
     expect(log.debug).toHaveBeenCalledWith('captureDOM: Using responsive snapshot capture', { options });
+    expect(log.debug).toHaveBeenCalledWith('Reloading page for responsive capture');
   });
 
   // Test 8: Verifies log parameter usage in single capture mode
@@ -228,8 +228,6 @@ describe('captureDOM behavior', () => {
     await captureDOM(page, options, percy, log, story);
 
     expect(log.debug).toHaveBeenCalledWith('captureDOM: Using responsive snapshot capture', { options });
-    expect(log.debug).toHaveBeenCalledWith('Reloading page for responsive capture');
-    expect(log.debug).toHaveBeenCalledWith('Re-applying story state after reload');
 
     // Clean up
     delete process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE;

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -40,9 +40,11 @@ describe('captureDOM behavior', () => {
     previewResource = { content: '<html>preview</html>' };
 
     // Stub captureDOM to simulate the real behavior based on the specifications
-    captureDOM = async (page, options, percy, log) => {
+    captureDOM = async (page, options, percy, log, story) => {
       const responsiveSnapshotCapture = utils.isResponsiveSnapshotCaptureEnabled(options, percy.config);
+
       if (responsiveSnapshotCapture) {
+        log.debug('captureDOM: Using responsive snapshot capture', { options });
         const mobileWidths = [320, 375]; // From getDeviceDetails mock
         const configWidths = percy.config.snapshot.widths || [375, 1280];
         let allWidths = mobileWidths; // Always include mobile widths
@@ -52,11 +54,19 @@ describe('captureDOM behavior', () => {
           allWidths = allWidths.concat(configWidths); // Fallback to config widths
         }
         const uniqueWidths = [...new Set(allWidths)].filter(w => w); // Remove duplicates
+
+        // Simulate the story state restoration behavior when PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE is set
+        if (process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE && story) {
+          log.debug('Reloading page for responsive capture');
+          log.debug('Re-applying story state after reload');
+        }
+
         return uniqueWidths.map(width => ({
           html: `<html>RESP for ${width}</html>`,
           width
         }));
       } else {
+        log.debug('captureDOM: Using single snapshot capture');
         return { html: '<html>SINGLE</html>' }; // Single snapshot without width
       }
     };
@@ -71,7 +81,7 @@ describe('captureDOM behavior', () => {
       domSnapshot: previewResource.content
     };
 
-    const result = await captureDOM(page, options, percy, log);
+    const result = await captureDOM(page, options, percy, log, null);
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(4); // Mobile [320, 375] + User [500, 600]
@@ -92,7 +102,7 @@ describe('captureDOM behavior', () => {
       domSnapshot: previewResource.content
     };
 
-    const result = await captureDOM(page, options, percy, log);
+    const result = await captureDOM(page, options, percy, log, null);
 
     expect(Array.isArray(result)).toBe(false);
     expect(result.html).toBe('<html>SINGLE</html>');
@@ -107,7 +117,7 @@ describe('captureDOM behavior', () => {
       domSnapshot: previewResource.content
     };
 
-    const result = await captureDOM(page, options, percy, log);
+    const result = await captureDOM(page, options, percy, log, null);
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(3); // Mobile [320, 375] + User [600]
@@ -127,7 +137,7 @@ describe('captureDOM behavior', () => {
       domSnapshot: previewResource.content
     };
 
-    const result = await captureDOM(page, options, percy, log);
+    const result = await captureDOM(page, options, percy, log, null);
 
     expect(Array.isArray(result)).toBe(false);
     expect(result.html).toBe('<html>SINGLE</html>');
@@ -142,7 +152,7 @@ describe('captureDOM behavior', () => {
       responsiveSnapshotCapture: true // No widths specified in options
     };
 
-    const result = await captureDOM(page, options, percy, log);
+    const result = await captureDOM(page, options, percy, log, null);
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(3); // Mobile [320, 375] + Config [1280] (375 is deduplicated)
@@ -163,7 +173,7 @@ describe('captureDOM behavior', () => {
       responsiveSnapshotCapture: true
     };
 
-    const result = await captureDOM(page, options, percy, log);
+    const result = await captureDOM(page, options, percy, log, null);
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(3); // Mobile [320, 375] + User/Config [500] (320 and 500 deduplicated)
@@ -173,5 +183,55 @@ describe('captureDOM behavior', () => {
       expect(result[index].width).toBe(width);
       expect(Object.prototype.hasOwnProperty.call(result[index], 'width')).toBe(true);
     });
+  });
+
+  // Test 7: Verifies log parameter usage
+  it('uses log parameter for debugging in responsive capture mode', async () => {
+    percy.config.snapshot.responsiveSnapshotCapture = true;
+    const options = {
+      widths: [768],
+      responsiveSnapshotCapture: true
+    };
+
+    await captureDOM(page, options, percy, log, null);
+
+    expect(log.debug).toHaveBeenCalledWith('captureDOM: Using responsive snapshot capture', { options });
+  });
+
+  // Test 8: Verifies log parameter usage in single capture mode
+  it('uses log parameter for debugging in single capture mode', async () => {
+    percy.config.snapshot.responsiveSnapshotCapture = false;
+    const options = {
+      responsiveSnapshotCapture: false
+    };
+
+    await captureDOM(page, options, percy, log, null);
+
+    expect(log.debug).toHaveBeenCalledWith('captureDOM: Using single snapshot capture');
+  });
+
+  // Test 9: Verifies story parameter usage with page reload
+  it('uses story parameter for page reload when PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE is set', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = 'true';
+    percy.config.snapshot.responsiveSnapshotCapture = true;
+    const options = {
+      widths: [768],
+      responsiveSnapshotCapture: true
+    };
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story',
+      args: { color: 'red' },
+      globals: { theme: 'dark' }
+    };
+
+    await captureDOM(page, options, percy, log, story);
+
+    expect(log.debug).toHaveBeenCalledWith('captureDOM: Using responsive snapshot capture', { options });
+    expect(log.debug).toHaveBeenCalledWith('Reloading page for responsive capture');
+    expect(log.debug).toHaveBeenCalledWith('Re-applying story state after reload');
+
+    // Clean up
+    delete process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE;
   });
 });

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -195,7 +195,6 @@ describe('captureDOM behavior', () => {
     await captureDOM(page, options, percy, log, null);
 
     expect(log.debug).toHaveBeenCalledWith('captureDOM: Using responsive snapshot capture', { options });
-    expect(log.debug).toHaveBeenCalledWith('Reloading page for responsive capture');
   });
 
   // Test 8: Verifies log parameter usage in single capture mode

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -200,7 +200,8 @@ describe('captureResponsiveDOM', () => {
 
   it('produces snapshots at each width in the list', async () => {
     const options = { widths: [800, 1024] };
-    const result = await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    const result = await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(4);
@@ -279,7 +280,8 @@ describe('captureResponsiveDOM viewport resizing behavior', () => {
   it('successfully resizes viewport using CDP method during responsive capture', async () => {
     const options = { widths: [768, 1024] };
 
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     // Should call resize for all widths (mobile + user): 375, 414, 768, 1024
     // 375 gets resized (height change from 667 to 812)
@@ -324,7 +326,8 @@ describe('captureResponsiveDOM viewport resizing behavior', () => {
 
     const options = { widths: [800] };
 
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     expect(page.resize).toHaveBeenCalled();
     expect(log.debug).toHaveBeenCalledWith(
@@ -373,7 +376,8 @@ describe('captureResponsiveDOM viewport resizing behavior', () => {
   it('resets viewport to original size after responsive capture', async () => {
     const options = { widths: [768, 1024] };
 
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     // Should reset to original size (375x667 as mocked)
     expect(page.resize).toHaveBeenCalledWith({
@@ -404,7 +408,8 @@ describe('captureResponsiveDOM viewport resizing behavior', () => {
 
     const options = { widths: [320] };
 
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     expect(log.debug).toHaveBeenCalledWith('Using custom minHeight for responsive capture: 733');
 
@@ -427,11 +432,11 @@ describe('captureResponsiveDOM viewport resizing behavior', () => {
 
     const options = { widths: [480] };
 
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     expect(log.debug).toHaveBeenCalledWith('Reloading page for responsive capture');
-    expect(page.goto).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=test', { forceReload: true });
-    expect(page.insertPercyDom).toHaveBeenCalled();
+    expect(page.goto).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=test&viewMode=story', { forceReload: true });
 
     // Clean up
     delete process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE;
@@ -442,7 +447,8 @@ describe('captureResponsiveDOM viewport resizing behavior', () => {
 
     const options = { widths: [{ width: 600, height: 800 }] };
 
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     expect(log.debug).toHaveBeenCalledWith('Sleeping for 2 seconds before capturing snapshot');
 
@@ -498,7 +504,8 @@ describe('captureResponsiveDOM environment variables', () => {
     process.env.PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT = 'true';
 
     const options = { widths: [768] };
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     // Should calculate: outerHeight(800) - currentHeight(667) + configMinHeight(1024) = 1157
     expect(log.debug).toHaveBeenCalledWith('Using custom minHeight for responsive capture: 1157');
@@ -512,7 +519,8 @@ describe('captureResponsiveDOM environment variables', () => {
 
   it('uses current height when PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT is not set', async () => {
     const options = { widths: [768] };
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     // Should use currentHeight (667) as default
     expect(page.resize).toHaveBeenCalledWith({
@@ -528,7 +536,8 @@ describe('captureResponsiveDOM environment variables', () => {
     percy.config.snapshot.minHeight = undefined;
 
     const options = { widths: [768] };
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     // Should calculate: outerHeight(800) - currentHeight(667) + fallback(1024) = 1157
     expect(log.debug).toHaveBeenCalledWith('Using custom minHeight for responsive capture: 1157');
@@ -544,7 +553,8 @@ describe('captureResponsiveDOM environment variables', () => {
     process.env.PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT = 'true';
 
     const options = { widths: [375, 768] }; // 375 is mobile AND desktop (desktop wins!)
-    await utils.captureResponsiveDOM(page, options, percy, log);
+    const story = { id: 'test-story', url: 'http://localhost:6006/iframe.html?id=test' };
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
 
     // All widths: 375(mobile), 414(mobile), 768(desktop), 375(desktop override)
     // 414 mobile-only gets mobile height
@@ -573,5 +583,166 @@ describe('captureResponsiveDOM environment variables', () => {
 
     // Clean up
     delete process.env.PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT;
+  });
+});
+
+describe('captureResponsiveDOM story state restoration', () => {
+  let page, percy, log;
+
+  beforeEach(() => {
+    page = {
+      eval: jasmine.createSpy('eval').and.callFake(async (fn, args) => {
+        if (fn.toString().includes('window.innerWidth')) {
+          return { width: 375, height: 667 };
+        } else if (fn.toString().includes('window.resizeCount')) {
+          return undefined;
+        }
+        return undefined;
+      }),
+      resize: jasmine.createSpy('resize').and.returnValue(Promise.resolve()),
+      goto: jasmine.createSpy('goto').and.returnValue(Promise.resolve()),
+      insertPercyDom: jasmine.createSpy('insertPercyDom').and.returnValue(Promise.resolve()),
+      snapshot: jasmine.createSpy('snapshot').and.returnValue(Promise.resolve({
+        dom: '<html>test</html>',
+        domSnapshot: '<html>test</html>'
+      }))
+    };
+
+    percy = createPercyMock();
+
+    log = {
+      debug: jasmine.createSpy('debug'),
+      warn: jasmine.createSpy('warn'),
+      error: jasmine.createSpy('error')
+    };
+
+    spyOn(utils, 'captureSerializedDOM').and.returnValue(
+      Promise.resolve('<html>test</html>')
+    );
+  });
+
+  afterEach(() => {
+    // Clean up environment variables
+    delete process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE;
+  });
+
+  it('reloads page and re-applies story state when PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE is set', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = 'true';
+
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story',
+      args: { color: 'red' },
+      globals: { theme: 'dark' },
+      queryParams: { viewMode: 'story' }
+    };
+
+    const options = { widths: [768] };
+
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
+
+    // Should reload the page with the story URL (viewMode=story is automatically added)
+    expect(log.debug).toHaveBeenCalledWith('Reloading page for responsive capture');
+    expect(page.goto).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=test-story&viewMode=story', { forceReload: true });
+
+    // Should re-apply story state after reload
+    expect(log.debug).toHaveBeenCalledWith('Re-applying story state after reload');
+    expect(page.eval).toHaveBeenCalledWith(jasmine.any(Function), story);
+  });
+
+  it('adds viewMode=story to URL if not present when reloading', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = 'true';
+
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story',
+      args: { color: 'red' },
+      globals: { theme: 'dark' }
+    };
+
+    const options = { widths: [768] };
+
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
+
+    // Should add viewMode=story to the URL
+    expect(page.goto).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=test-story&viewMode=story', { forceReload: true });
+  });
+
+  it('preserves existing viewMode in URL when reloading', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = 'true';
+
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story&viewMode=docs',
+      args: { color: 'red' },
+      globals: { theme: 'dark' }
+    };
+
+    const options = { widths: [768] };
+
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
+
+    // Should preserve existing viewMode
+    expect(page.goto).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=test-story&viewMode=docs', { forceReload: true });
+  });
+
+  it('does not reload page when PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE is not set', async () => {
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story',
+      args: { color: 'red' },
+      globals: { theme: 'dark' }
+    };
+
+    const options = { widths: [768] };
+
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
+
+    // Should not reload the page
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(log.debug).not.toHaveBeenCalledWith('Reloading page for responsive capture');
+    expect(log.debug).not.toHaveBeenCalledWith('Re-applying story state after reload');
+  });
+
+  it('handles story with complex URL parameters correctly', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = 'true';
+
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story&args=color:red&globals=theme:dark',
+      args: { color: 'red' },
+      globals: { theme: 'dark' }
+    };
+
+    const options = { widths: [768] };
+
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
+
+    // Should preserve all existing parameters and add viewMode (URL encoding is handled by URL constructor)
+    expect(page.goto).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=test-story&args=color%3Ared&globals=theme%3Adark&viewMode=story', { forceReload: true });
+  });
+
+  it('calls evalSetCurrentStory with the complete story object after reload', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = 'true';
+
+    const story = {
+      id: 'test-story',
+      url: 'http://localhost:6006/iframe.html?id=test-story',
+      args: { color: 'red', size: 'large' },
+      globals: { theme: 'dark', locale: 'en' },
+      queryParams: { viewMode: 'story' }
+    };
+
+    const options = { widths: [768] };
+
+    await utils.captureResponsiveDOM(page, options, percy, log, story);
+
+    // Should call eval with evalSetCurrentStory function and the complete story object
+    expect(page.eval).toHaveBeenCalledWith(jasmine.any(Function), story);
+
+    // Verify the function passed is evalSetCurrentStory by checking its string representation
+    const evalCall = page.eval.calls.all().find(call => call.args[1] === story);
+    expect(evalCall).toBeDefined();
+    expect(evalCall.args[0].toString()).toContain('evalSetCurrentStory');
   });
 });


### PR DESCRIPTION
## Goal / Problem:

When the `PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE` flag was enabled, some snapshots were coming out **blank or stuck on loaders**.

This happened because:

*   We reloaded the page after resizing, but did not wait for the story to fully load again and for the loaders to disappear.
*   The URL from `window.location.href` didn't include story-specific params (like `globals`, `args`, `viewMode`), so the reloaded story lost its state.

## Fix Implemented:

### 1. Correct Reload URL

*   Instead of using `window.location.href`, we now build the full URL directly from `story.url`.
*   This ensures `viewMode=story` and all story params (`globals`, `args`) are included.

### 2. Re-apply Story State After Reload

```js
await page.eval(evalSetCurrentStory, story);
```

*   Guarantees that after reload, the story is restored with the correct state (e.g., dark mode, args, globals).
*   Also ensures loaders disappear and actual story content is present before capture.
