### PR TITLE
Await snapshot promise to avoid snapshots being taken of the wrong story

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -278,7 +278,7 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
               const options = yield* processStory(page, currentStory, previewResource, percy, flags, log);
 
               // Take the snapshot
-              percy.snapshot(options);
+              yield percy.snapshot(options);
 
               // Update previous story tracking
               previousStory = currentStory;


### PR DESCRIPTION
My team is currently using `@percy/storybook` for taking snapshots of our component stories in our Linux CI environment and we've been running into flaky issues with percy taking a snapshot of the wrong story. I think it's due to the snapshot command not being awaited because I've been testing this fix in our CI runs and haven't run into the flaky snapshot issue yet.