### PR TITLE
release 10.0.1-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/storybook",
-  "version": "10.0.1-beta.0",
+  "version": "10.0.1-beta.1",
   "description": "Storybook addons for visual testing with Percy",
   "keywords": [
     "storybook",


### PR DESCRIPTION
## Summary
- Bump version from `10.0.1-beta.0` to `10.0.1-beta.1` to publish another beta build

## Test plan
- [ ] CI passes
- [ ] Package publishes to npm under the `beta` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)