### PR TITLE
fix: include viewMode in story URL to prevent 404 on re-render

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -343,7 +343,8 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
 
       try {
         // Use a single page for as many stories as possible until a context error occurs
-        yield* withPage(percy, snapshots[0].url, async function*(page) {
+        // Only id and viewMode are needed here — args/globals are applied via evalSetCurrentStory channel events
+        yield* withPage(percy, `${previewUrl}?id=${snapshots[0].id}&viewMode=${snapshots[0].type === 'docs' ? 'docs' : 'story'}`, async function*(page) {
           // Process snapshots one by one with the current page
           while (snapshots.length) {
             try {

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -16,7 +16,8 @@ import {
   hasRules,
   getDocCaptureFlagsWithRules,
   generateDocRuleOptions,
-  isDocAutodoc
+  isDocAutodoc,
+  viewModeFor
 } from './utils.js';
 
 // Main capture function
@@ -235,7 +236,7 @@ function mapStorybookSnapshots(stories, { previewUrl, flags, config, globalDocSe
     if (story.globals) url += `&globals=${buildStorybookArgsParam(story.globals)}`;
     for (let [k, v] of Object.entries(story.queryParams ?? {})) url += `&${k}=${v}`;
     if (!story.queryParams?.viewMode) {
-      url += `&viewMode=${story.type === 'docs' ? 'docs' : 'story'}`;
+      url += `&viewMode=${viewModeFor(story)}`;
     }
     return Object.assign(story, { url });
   });
@@ -344,7 +345,7 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
       try {
         // Use a single page for as many stories as possible until a context error occurs
         // Only id and viewMode are needed here — args/globals are applied via evalSetCurrentStory channel events
-        yield* withPage(percy, `${previewUrl}?id=${snapshots[0].id}&viewMode=${snapshots[0].type === 'docs' ? 'docs' : 'story'}`, async function*(page) {
+        yield* withPage(percy, `${previewUrl}?id=${snapshots[0].id}&viewMode=${viewModeFor(snapshots[0])}`, async function*(page) {
           // Process snapshots one by one with the current page
           while (snapshots.length) {
             try {

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -234,6 +234,9 @@ function mapStorybookSnapshots(stories, { previewUrl, flags, config, globalDocSe
     if (story.args) url += `&args=${buildStorybookArgsParam(story.args)}`;
     if (story.globals) url += `&globals=${buildStorybookArgsParam(story.globals)}`;
     for (let [k, v] of Object.entries(story.queryParams ?? {})) url += `&${k}=${v}`;
+    if (!story.queryParams?.viewMode) {
+      url += `&viewMode=${story.type === 'docs' ? 'docs' : 'story'}`;
+    }
     return Object.assign(story, { url });
   });
 }
@@ -340,7 +343,7 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
 
       try {
         // Use a single page for as many stories as possible until a context error occurs
-        yield* withPage(percy, `${previewUrl}?id=${snapshots[0].id}&viewMode=story`, async function*(page) {
+        yield* withPage(percy, snapshots[0].url, async function*(page) {
           // Process snapshots one by one with the current page
           while (snapshots.length) {
             try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,10 @@ import { logger } from '@percy/cli-command';
 import spawn from 'cross-spawn';
 import globToRegExp from 'glob-to-regexp';
 
+export function viewModeFor(story) {
+  return story.type === 'docs' ? 'docs' : 'story';
+}
+
 // check storybook version
 export function checkStorybookVersion() {
   return new Promise((resolve, reject) => {
@@ -665,7 +669,7 @@ export async function captureResponsiveDOM(page, options, percy, log, story) {
       // Build the complete URL with all story parameters
       const url = new URL(story.url);
       if (!url.searchParams.has('viewMode')) {
-        url.searchParams.set('viewMode', story.type === 'docs' ? 'docs' : 'story');
+        url.searchParams.set('viewMode', viewModeFor(story));
       }
       const reloadUrl = url.toString();
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -665,7 +665,7 @@ export async function captureResponsiveDOM(page, options, percy, log, story) {
       // Build the complete URL with all story parameters
       const url = new URL(story.url);
       if (!url.searchParams.has('viewMode')) {
-        url.searchParams.set('viewMode', 'story');
+        url.searchParams.set('viewMode', story.type === 'docs' ? 'docs' : 'story');
       }
       const reloadUrl = url.toString();
 

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -938,7 +938,7 @@ describe('percy storybook', () => {
         '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
       ].join('')]);
 
-      server.reply('/iframe.html?id=todoitem--docs&viewMode=story', () => [200, 'text/html', [
+      server.reply('/iframe.html?id=todoitem--docs&viewMode=docs', () => [200, 'text/html', [
         `<script>__STORYBOOK_PREVIEW__ = ${FAKE_PREVIEW}</script>`,
         '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
       ].join('')]);
@@ -1070,7 +1070,7 @@ describe('percy storybook', () => {
         '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
       ].join('')]);
 
-      server.reply('/iframe.html?id=todoitem--docs&viewMode=story', () => [200, 'text/html', [
+      server.reply('/iframe.html?id=todoitem--docs&viewMode=docs', () => [200, 'text/html', [
         `<script>__STORYBOOK_PREVIEW__ = ${FAKE_PREVIEW}</script>`,
         '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
       ].join('')]);
@@ -1114,7 +1114,7 @@ describe('percy storybook', () => {
         '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
       ].join('')]);
 
-      server.reply('/iframe.html?id=todoitem--docs&viewMode=story', () => [200, 'text/html', [
+      server.reply('/iframe.html?id=todoitem--docs&viewMode=docs', () => [200, 'text/html', [
         `<script>__STORYBOOK_PREVIEW__ = ${FAKE_PREVIEW}</script>`,
         '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
       ].join('')]);

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -531,23 +531,23 @@ describe('percy storybook', () => {
     ]));
 
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
-      '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=args--args',
+      '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=args--args&viewMode=story',
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=args--args&args=' +
-        'text:Snapshot+custom+args;style.font:1rem+sans-serif',
+        'text:Snapshot+custom+args;style.font:1rem+sans-serif&viewMode=story',
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=args--args&args=' +
-        'text:Snapshot+custom+bold+args;style.font:1rem+sans-serif;style.fontWeight:bold',
+        'text:Snapshot+custom+bold+args;style.font:1rem+sans-serif;style.fontWeight:bold&viewMode=story',
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=args--args&args=' +
         'text:Snapshot+purple+args;' +
         'style.font:1rem+sans-serif;' +
         'style.fontWeight:bold;' +
-        'style.color:purple',
+        'style.color:purple&viewMode=story',
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=args--args&args=' +
         'null:!null;undefined:!undefined;' +
         'smallNum:3;largeNum:12000000;' +
         'date:!date(2022-01-01T00:00:00.000Z);' +
         'rgb:!rgb(20,30,40);rgba:!rgba(20,30,40,.5);' +
         'hsl:!hsl(120,80,30);hsla:!hsla(120,80,30,.5);' +
-        'shortHex:!hex(c6c);longHex:!hex(a907cf);alphaHex:!hex(a907cf9f)'
+        'shortHex:!hex(c6c);longHex:!hex(a907cf);alphaHex:!hex(a907cf9f)&viewMode=story'
     ]));
   });
 
@@ -632,13 +632,13 @@ describe('percy storybook', () => {
     ]));
 
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
-      '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=mixed--params',
+      '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=mixed--params&viewMode=story',
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=mixed--params' +
-        '&globals=text:+with+globals',
+        '&globals=text:+with+globals&viewMode=story',
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=mixed--params' +
-        `&text=${encodeURIComponent(' with query params')}`,
+        `&text=${encodeURIComponent(' with query params')}&viewMode=story`,
       '[percy:core:snapshot] - url: http://localhost:9000/iframe.html?id=mixed--params' +
-        `&args=text:Args&globals=text:+globals&text=${encodeURIComponent(' and params')}`
+        `&args=text:Args&globals=text:+globals&text=${encodeURIComponent(' and params')}&viewMode=story`
     ]));
   });
 


### PR DESCRIPTION
## Summary
- **Root cause**: `story.url` sent to percy-infra for re-rendering was missing the `viewMode` query parameter. Storybook redirects when `viewMode` is absent, and the redirected URL wasn't in the proxy map, causing a 404.
- Always append `viewMode` to the constructed story URL (`docs` → `viewMode=docs`, stories → `viewMode=story`), respecting any user-provided `queryParams`
- Use `snapshots[0].url` in the `withPage` call instead of rebuilding the URL with hardcoded `viewMode=story`
- Respect story type in the responsive capture reload fallback

Fixes: [PER-7996](https://browserstack.atlassian.net/browse/PER-7996)

## Test plan
- [ ] Verify regular stories have `viewMode=story` in their URL
- [ ] Verify doc entries have `viewMode=docs` in their URL
- [ ] Verify user-provided `viewMode` in `queryParams` is not overridden
- [ ] Verify responsive capture reload uses correct `viewMode` per story type
- [ ] Run existing test suite to confirm no regressions
- [ ] Run [example-percy-storybook](https://github.com/percy/example-percy-storybook) to confirm builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-7996]: https://browserstack.atlassian.net/browse/PER-7996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ