### PR TITLE
Warn (non-blocking) when a story's play function errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,33 @@ storybook:
   additionalSnapshots: []
   include: []
   exclude: []
+  failOnStoryError: false
 ```
 
 See the [configuration options above](#configuration) for details about each accepted config file
 option (**note**: the `skip` and `name` parameters are _not_ accepted as Percy config file options).
+
+### `failOnStoryError`
+
+By default a story whose `play` function throws (for example a failed interaction or assertion)
+still produces a snapshot and does **not** fail the build — Percy resolves once the story has
+rendered, before the interaction is verified. This means broken interactive stories can go
+unnoticed in CI.
+
+Set `failOnStoryError: true` (or the `PERCY_FAIL_ON_STORY_ERROR=true` environment variable) to make
+`percy storybook` fail when a story's `play` function throws or reports an unhandled error, so CI can
+catch broken interactive stories:
+
+``` yaml
+# .percy.yml
+version: 2
+storybook:
+  failOnStoryError: true
+```
+
+``` sh
+$ PERCY_FAIL_ON_STORY_ERROR=true percy storybook ./storybook-static
+```
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -258,14 +258,20 @@ option (**note**: the `skip` and `name` parameters are _not_ accepted as Percy c
 
 ### `failOnStoryError`
 
-By default a story whose `play` function throws (for example a failed interaction or assertion)
-still produces a snapshot and does **not** fail the build — Percy resolves once the story has
-rendered, before the interaction is verified. This means broken interactive stories can go
-unnoticed in CI.
+When a story's `play` function throws (for example a failed interaction or assertion), Storybook
+still renders the story, so Percy captures the snapshot — but that snapshot may not reflect the
+interaction (e.g. a click that never landed).
 
-Set `failOnStoryError: true` (or the `PERCY_FAIL_ON_STORY_ERROR=true` environment variable) to make
-`percy storybook` fail when a story's `play` function throws or reports an unhandled error, so CI can
-catch broken interactive stories:
+By default Percy now **logs a warning** for these stories and **still takes the snapshot** (non-blocking),
+so you understand that the interaction did not complete without losing the snapshot:
+
+```
+[percy] <story name>: the story's play function reported an error, so this snapshot may not reflect the interaction. <error>
+```
+
+Set `failOnStoryError: true` (or the `PERCY_FAIL_ON_STORY_ERROR=true` environment variable) to instead
+**fail the build** when a story's `play` function throws or reports an unhandled error, so CI can hard-fail
+on broken interactive stories:
 
 ``` yaml
 # .percy.yml

--- a/README.md
+++ b/README.md
@@ -250,38 +250,20 @@ storybook:
   additionalSnapshots: []
   include: []
   exclude: []
-  failOnStoryError: false
 ```
 
 See the [configuration options above](#configuration) for details about each accepted config file
 option (**note**: the `skip` and `name` parameters are _not_ accepted as Percy config file options).
 
-### `failOnStoryError`
+### Play function errors
 
 When a story's `play` function throws (for example a failed interaction or assertion), Storybook
 still renders the story, so Percy captures the snapshot — but that snapshot may not reflect the
-interaction (e.g. a click that never landed).
-
-By default Percy now **logs a warning** for these stories and **still takes the snapshot** (non-blocking),
-so you understand that the interaction did not complete without losing the snapshot:
+interaction (e.g. a click that never landed). Percy logs a warning for these stories so you know the
+interaction did not complete, and still takes the snapshot:
 
 ```
 [percy] <story name>: the story's play function reported an error, so this snapshot may not reflect the interaction. <error>
-```
-
-Set `failOnStoryError: true` (or the `PERCY_FAIL_ON_STORY_ERROR=true` environment variable) to instead
-**fail the build** when a story's `play` function throws or reports an unhandled error, so CI can hard-fail
-on broken interactive stories:
-
-``` yaml
-# .percy.yml
-version: 2
-storybook:
-  failOnStoryError: true
-```
-
-``` sh
-$ PERCY_FAIL_ON_STORY_ERROR=true percy storybook ./storybook-static
 ```
 
 ## Upgrading

--- a/src/config.js
+++ b/src/config.js
@@ -179,10 +179,6 @@ export const configSchema = {
       }
     ],
     properties: {
-      failOnStoryError: {
-        type: 'boolean',
-        default: false
-      },
       docs: {
         type: 'object',
         default: {},

--- a/src/config.js
+++ b/src/config.js
@@ -179,6 +179,10 @@ export const configSchema = {
       }
     ],
     properties: {
+      failOnStoryError: {
+        type: 'boolean',
+        default: false
+      },
       docs: {
         type: 'object',
         default: {},

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -268,11 +268,7 @@ async function* processStory(page, story, previewResource, percy, flags, log) {
   } else {
     log.debug(`Loading story: ${options.name}`);
     // when not dry-running and javascript is not enabled, capture the story dom
-    // when failOnStoryError is set, a failing play function fails the build;
-    // otherwise the play error is reported back so we can warn (non-blocking)
-    let failOnStoryError = (percy.config.storybook?.failOnStoryError ?? false) ||
-      process.env.PERCY_FAIL_ON_STORY_ERROR === 'true';
-    let renderResult = yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams, failOnStoryError });
+    let renderResult = yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
     // A play function threw but we still snapshot — warn so the user understands the
     // snapshot may not reflect the interaction (e.g. a click that never landed).
     if (renderResult?.playError) {

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -268,10 +268,17 @@ async function* processStory(page, story, previewResource, percy, flags, log) {
   } else {
     log.debug(`Loading story: ${options.name}`);
     // when not dry-running and javascript is not enabled, capture the story dom
-    // optionally surface play/interaction errors so broken interactive stories fail the build
+    // when failOnStoryError is set, a failing play function fails the build;
+    // otherwise the play error is reported back so we can warn (non-blocking)
     let failOnStoryError = (percy.config.storybook?.failOnStoryError ?? false) ||
       process.env.PERCY_FAIL_ON_STORY_ERROR === 'true';
-    yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams, failOnStoryError });
+    let renderResult = yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams, failOnStoryError });
+    // A play function threw but we still snapshot — warn so the user understands the
+    // snapshot may not reflect the interaction (e.g. a click that never landed).
+    if (renderResult?.playError) {
+      log.warn(`${options.name}: the story's play function reported an error, so this snapshot may ` +
+        `not reflect the interaction. ${renderResult.playError}`);
+    }
     options.domSnapshot = await captureDOM(page, options, percy, log, story);
   }
 

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -268,7 +268,10 @@ async function* processStory(page, story, previewResource, percy, flags, log) {
   } else {
     log.debug(`Loading story: ${options.name}`);
     // when not dry-running and javascript is not enabled, capture the story dom
-    yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
+    // optionally surface play/interaction errors so broken interactive stories fail the build
+    let failOnStoryError = (percy.config.storybook?.failOnStoryError ?? false) ||
+      process.env.PERCY_FAIL_ON_STORY_ERROR === 'true';
+    yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams, failOnStoryError });
     options.domSnapshot = await captureDOM(page, options, percy, log, story);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -352,7 +352,7 @@ export function evalSetCurrentStory({ waitFor }, story) {
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'
   ))).then(channel => {
-    let { id, queryParams, globals, args, failOnStoryError } = story;
+    let { id, queryParams, globals, args } = story;
 
     // emit a series of events to render the desired story
     channel.emit('setCurrentStory', { storyId: id });
@@ -386,21 +386,14 @@ export function evalSetCurrentStory({ waitFor }, story) {
       // A failing `play` function (e.g. a thrown assertion or an interaction that
       // never lands) is reported by Storybook on these channels rather than as a
       // render exception. Without subscribing to them Percy resolves on
-      // `storyRendered` and silently snapshots the un-interacted DOM. We capture
-      // the failure so the caller can warn that the snapshot may not reflect the
-      // interaction — but we still take the snapshot (non-blocking). Teams that
-      // want CI to fail can opt in with `failOnStoryError`.
+      // `storyRendered` and silently snapshots the un-interacted DOM. Capture the
+      // failure so the caller can warn that the snapshot may not reflect the
+      // interaction — the snapshot is still taken (non-blocking).
       const handlePlayError = (err, fallback) => {
-        let message;
         try {
-          message = (err && err.message) || (typeof err === 'string' ? err : (err && JSON.stringify(err))) || fallback;
+          playError = (err && err.message) || (typeof err === 'string' ? err : (err && JSON.stringify(err))) || fallback;
         } catch (e) {
-          message = fallback;
-        }
-        if (failOnStoryError) {
-          reject(err || new Error(fallback));
-        } else {
-          playError = message;
+          playError = fallback;
         }
       };
       channel.on('playFunctionThrewException', (err) => handlePlayError(err, 'Play Function Threw Exception'));

--- a/src/utils.js
+++ b/src/utils.js
@@ -352,7 +352,7 @@ export function evalSetCurrentStory({ waitFor }, story) {
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'
   ))).then(channel => {
-    let { id, queryParams, globals, args } = story;
+    let { id, queryParams, globals, args, failOnStoryError } = story;
 
     // emit a series of events to render the desired story
     channel.emit('setCurrentStory', { storyId: id });
@@ -378,6 +378,17 @@ export function evalSetCurrentStory({ waitFor }, story) {
       channel.on('storyMissing', (err) => reject(err || new Error('Story Missing')));
       channel.on('storyErrored', (err) => reject(err || new Error('Story Errored')));
       channel.on('storyThrewException', (err) => reject(err || new Error('Story Threw Exception')));
+
+      // A failing `play` function (e.g. a thrown assertion or interaction that
+      // never lands) is reported by Storybook on these channels rather than as
+      // a render exception, so without subscribing to them Percy resolves on
+      // `storyRendered` and silently snapshots the un-interacted DOM. When
+      // `failOnStoryError` is enabled, surface those failures so CI can catch
+      // broken interactive stories. Opt-in to preserve existing behavior.
+      if (failOnStoryError) {
+        channel.on('playFunctionThrewException', (err) => reject(err || new Error('Play Function Threw Exception')));
+        channel.on('unhandledErrorsWhilePlaying', (err) => reject(err || new Error('Unhandled Errors While Playing')));
+      }
     });
 
     // Helper function to wait for all loaders to disappear

--- a/src/utils.js
+++ b/src/utils.js
@@ -363,12 +363,16 @@ export function evalSetCurrentStory({ waitFor }, story) {
 
     // resolve when rendered, reject on any other renderer event
     return new Promise((resolve, reject) => {
+      // Capture a play-function failure (if any) so the caller can warn about it.
+      // We still resolve and snapshot the story — the failure is surfaced, not blocking.
+      let playError = null;
+
       const handleRendered = () => {
         // After the story/docs is rendered, add a small delay before checking loaders
         // This helps ensure that any post-render loader state changes have time to occur
         setTimeout(() => {
           // Wait for any loaders to disappear before resolving
-          waitForLoadersToDisappear().then(resolve).catch(reject);
+          waitForLoadersToDisappear().then(() => resolve({ playError })).catch(reject);
         }, 100);
       };
 
@@ -379,16 +383,28 @@ export function evalSetCurrentStory({ waitFor }, story) {
       channel.on('storyErrored', (err) => reject(err || new Error('Story Errored')));
       channel.on('storyThrewException', (err) => reject(err || new Error('Story Threw Exception')));
 
-      // A failing `play` function (e.g. a thrown assertion or interaction that
-      // never lands) is reported by Storybook on these channels rather than as
-      // a render exception, so without subscribing to them Percy resolves on
-      // `storyRendered` and silently snapshots the un-interacted DOM. When
-      // `failOnStoryError` is enabled, surface those failures so CI can catch
-      // broken interactive stories. Opt-in to preserve existing behavior.
-      if (failOnStoryError) {
-        channel.on('playFunctionThrewException', (err) => reject(err || new Error('Play Function Threw Exception')));
-        channel.on('unhandledErrorsWhilePlaying', (err) => reject(err || new Error('Unhandled Errors While Playing')));
-      }
+      // A failing `play` function (e.g. a thrown assertion or an interaction that
+      // never lands) is reported by Storybook on these channels rather than as a
+      // render exception. Without subscribing to them Percy resolves on
+      // `storyRendered` and silently snapshots the un-interacted DOM. We capture
+      // the failure so the caller can warn that the snapshot may not reflect the
+      // interaction — but we still take the snapshot (non-blocking). Teams that
+      // want CI to fail can opt in with `failOnStoryError`.
+      const handlePlayError = (err, fallback) => {
+        let message;
+        try {
+          message = (err && err.message) || (typeof err === 'string' ? err : (err && JSON.stringify(err))) || fallback;
+        } catch (e) {
+          message = fallback;
+        }
+        if (failOnStoryError) {
+          reject(err || new Error(fallback));
+        } else {
+          playError = message;
+        }
+      };
+      channel.on('playFunctionThrewException', (err) => handlePlayError(err, 'Play Function Threw Exception'));
+      channel.on('unhandledErrorsWhilePlaying', (err) => handlePlayError(err, 'Unhandled Errors While Playing'));
     });
 
     // Helper function to wait for all loaders to disappear

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -239,9 +239,9 @@ describe('percy storybook', () => {
     ]));
   });
 
-  it('does not fail on a play function error by default (opt-in)', async () => {
-    // The channel offers both events; without the flag Percy only subscribes to
-    // storyRendered, so the play error is never observed and the build resolves.
+  it('warns but still snapshots when a play function errors (default, non-blocking)', async () => {
+    // The story renders AND its play function reports an error. By default Percy
+    // captures the snapshot and warns — it must not reject the build.
     let channel = 'channel: { emit() {}, on: (a, c) => { ' +
       'if (a === "storyRendered") c(); ' +
       'if (a === "playFunctionThrewException") c(new Error("Play Error")); } }';
@@ -261,8 +261,12 @@ describe('percy storybook', () => {
       ])} }</script>`
     ].join('')]);
 
-    // Without the flag, a play error must not reject the build.
+    // Build must succeed (snapshot still taken)...
     await expectAsync(storybook(['http://localhost:8000'])).toBeResolved();
+    // ...and a non-blocking warning must surface the play error.
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      jasmine.stringMatching(/play function reported an error, so this snapshot may not reflect the interaction\. Play Error/)
+    ]));
   });
 
   describe('with PERCY_SKIP_STORY_ON_ERROR set to true', () => {

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -52,7 +52,6 @@ describe('percy storybook', () => {
     delete process.env.PERCY_TOKEN;
     delete process.env.PERCY_ENABLE;
     delete process.env.PERCY_CLIENT_ERROR_LOGS;
-    delete process.env.PERCY_FAIL_ON_STORY_ERROR;
   });
 
   it('snapshots live urls', async () => {
@@ -204,42 +203,7 @@ describe('percy storybook', () => {
     ]));
   });
 
-  it('errors when a story play function throws and PERCY_FAIL_ON_STORY_ERROR is set', async () => {
-    process.env.PERCY_FAIL_ON_STORY_ERROR = true;
-    process.env.PERCY_RETRY_STORY_ON_ERROR = false;
-    server.reply('/iframe.html', () => [200, 'text/html', [
-      `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
-        { id: '1', kind: 'foo', name: 'bar' }
-      ])}  }, ${
-        'channel: { emit() {}, on: (a, c) => a === "playFunctionThrewException" && c(new Error("Play Error")) }'
-      } }</script>`,
-      `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
-        { id: '1', kind: 'foo', name: 'bar' }
-      ])} }</script>`
-    ].join('')]);
-
-    server.reply('/iframe.html?id=1&viewMode=story', () => [200, 'text/html', [
-      `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
-        { id: '1', kind: 'foo', name: 'bar' }
-      ])}  }, ${
-        'channel: { emit() {}, on: (a, c) => a === "playFunctionThrewException" && c(new Error("Play Error")) }'
-      } }</script>`,
-      `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
-        { id: '1', kind: 'foo', name: 'bar' }
-      ])} }</script>`
-    ].join('')]);
-
-    await expectAsync(storybook(['http://localhost:8000']))
-      .toBeRejectedWithError(/Play Error\n.*\/iframe\.html.*$/s);
-
-    expect(logger.stderr).toEqual(jasmine.arrayContaining([
-      '[percy] Detected error for percy build',
-      '[percy] Failure: Snapshot command was not called',
-      jasmine.stringMatching(/^\[percy\] Error: Snapshot Name:/s)
-    ]));
-  });
-
-  it('warns but still snapshots when a play function errors (default, non-blocking)', async () => {
+  it('warns but still snapshots when a play function errors (non-blocking)', async () => {
     // The story renders AND its play function reports an error. By default Percy
     // captures the snapshot and warns — it must not reject the build.
     let channel = 'channel: { emit() {}, on: (a, c) => { ' +

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -213,7 +213,9 @@ describe('percy storybook', () => {
       `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
         { id: '1', kind: 'foo', name: 'bar' }
       ])}  }, ${channel} }</script>`,
-      '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
+      `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])} }</script>`
     ].join('')]);
 
     server.reply('/iframe.html?id=1&viewMode=story', () => [200, 'text/html', [

--- a/test/storybook.test.js
+++ b/test/storybook.test.js
@@ -52,6 +52,7 @@ describe('percy storybook', () => {
     delete process.env.PERCY_TOKEN;
     delete process.env.PERCY_ENABLE;
     delete process.env.PERCY_CLIENT_ERROR_LOGS;
+    delete process.env.PERCY_FAIL_ON_STORY_ERROR;
   });
 
   it('snapshots live urls', async () => {
@@ -201,6 +202,67 @@ describe('percy storybook', () => {
       )
 
     ]));
+  });
+
+  it('errors when a story play function throws and PERCY_FAIL_ON_STORY_ERROR is set', async () => {
+    process.env.PERCY_FAIL_ON_STORY_ERROR = true;
+    process.env.PERCY_RETRY_STORY_ON_ERROR = false;
+    server.reply('/iframe.html', () => [200, 'text/html', [
+      `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])}  }, ${
+        'channel: { emit() {}, on: (a, c) => a === "playFunctionThrewException" && c(new Error("Play Error")) }'
+      } }</script>`,
+      `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])} }</script>`
+    ].join('')]);
+
+    server.reply('/iframe.html?id=1&viewMode=story', () => [200, 'text/html', [
+      `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])}  }, ${
+        'channel: { emit() {}, on: (a, c) => a === "playFunctionThrewException" && c(new Error("Play Error")) }'
+      } }</script>`,
+      `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])} }</script>`
+    ].join('')]);
+
+    await expectAsync(storybook(['http://localhost:8000']))
+      .toBeRejectedWithError(/Play Error\n.*\/iframe\.html.*$/s);
+
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      '[percy] Detected error for percy build',
+      '[percy] Failure: Snapshot command was not called',
+      jasmine.stringMatching(/^\[percy\] Error: Snapshot Name:/s)
+    ]));
+  });
+
+  it('does not fail on a play function error by default (opt-in)', async () => {
+    // The channel offers both events; without the flag Percy only subscribes to
+    // storyRendered, so the play error is never observed and the build resolves.
+    let channel = 'channel: { emit() {}, on: (a, c) => { ' +
+      'if (a === "storyRendered") c(); ' +
+      'if (a === "playFunctionThrewException") c(new Error("Play Error")); } }';
+    server.reply('/iframe.html', () => [200, 'text/html', [
+      `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])}  }, ${channel} }</script>`,
+      '<script>__STORYBOOK_STORY_STORE__ = { raw: () => [] }</script>'
+    ].join('')]);
+
+    server.reply('/iframe.html?id=1&viewMode=story', () => [200, 'text/html', [
+      `<script>__STORYBOOK_PREVIEW__ = { async extract() { return ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])}  }, ${channel} }</script>`,
+      `<script>__STORYBOOK_STORY_STORE__ = { raw: () => ${JSON.stringify([
+        { id: '1', kind: 'foo', name: 'bar' }
+      ])} }</script>`
+    ].join('')]);
+
+    // Without the flag, a play error must not reject the build.
+    await expectAsync(storybook(['http://localhost:8000'])).toBeResolved();
   });
 
   describe('with PERCY_SKIP_STORY_ON_ERROR set to true', () => {


### PR DESCRIPTION
## Problem

When a story's `play` function throws — a failed interaction or a failed `expect` assertion — `percy storybook` finalizes a **green build with exit 0** and gives no indication anything went wrong. The snapshot is captured in its **un-interacted state** (e.g. a click that never landed), so visual diffs silently test the wrong thing.

### Root cause

Storybook reports a failing `play` function on the **`playFunctionThrewException`** / **`unhandledErrorsWhilePlaying`** channel events — *not* as a render exception. A failed play still fires `storyRendered` (rendering succeeded; play is a later phase).

`evalSetCurrentStory` (`src/utils.js`) only subscribes to:

```
storyRendered, docsRendered            → resolve
storyMissing, storyErrored, storyThrewException → reject
```

It resolves on `storyRendered` and never listens for the play-failure events, so the error is silently dropped.

This is the SDK-side half of the behavior reported in #1286 and related support tickets ("Percy completes without any detailed errors even though play functions are failing").

## Fix

`evalSetCurrentStory` now also subscribes to `playFunctionThrewException` / `unhandledErrorsWhilePlaying`, captures the error, and resolves with `{ playError }`. `processStory` logs a **non-blocking warning** so the user understands the snapshot may not reflect the interaction — the snapshot is still taken:

```
[percy] <story>: the story's play function reported an error, so this snapshot may not reflect the interaction. <error>
```

No new config, no env var, no behavior switch — it simply warns instead of failing silently. The snapshot is never blocked.

## Changes
- `src/utils.js` — `evalSetCurrentStory` captures play-failure events and resolves with `{ playError }` (never rejects on a play failure).
- `src/snapshots.js` — `processStory` logs the non-blocking warning when a `playError` is reported.
- `test/storybook.test.js` — coverage: warns + still snapshots when a play function errors.
- `README.md` — document the warning under "Play function errors".

## Verification
- Lint passes on all changed files; Babel compiles.
- Reproduced against a minimal hydration repro on `@percy/storybook@9.1.0` (Percy build #440): both failing stories produce a clear warning naming the real play error (`Unable to find an element by: [data-testid="toggle-button"]` and `expect(element).toHaveTextContent()`), all snapshots are still captured, and the build finalizes with exit 0.
- New unit test mirrors the existing `storyErrored` harness. The full jasmine suite needs the Storybook manager build (tailwind/vite) — left to CI.