### PR TITLE
Bump version to 10.0.1-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/storybook",
-  "version": "10.0.1-beta.3",
+  "version": "10.0.1-beta.4",
   "description": "Storybook addons for visual testing with Percy",
   "keywords": [
     "storybook",


### PR DESCRIPTION
Bumps the package version `10.0.1-beta.3` → `10.0.1-beta.4` for the next beta release.

Single change to `package.json`. No code changes.

Intended to publish a beta that includes the play-function warning fix from #1310 once merged.