### PR TITLE
Add supply-chain hardened .npmrc (PER-8328)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@ docs
 CLAUDE.md
 *.log
 log/
-.npmrc
 debug-storybook.log
 src/styles/_compiled.css

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
 @browserstack:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
 registry=https://registry.npmjs.org
 auto-install-peers=true
 link-workspace-packages=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+@browserstack:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org
+auto-install-peers=true
+link-workspace-packages=false
+save-exact=true
+legacy-peer-deps=true
+strict-ssl=true
+audit-level=high

--- a/.npmrc.config
+++ b/.npmrc.config
@@ -5,3 +5,5 @@ auto-install-peers=true
 link-workspace-packages=false
 save-exact=true
 legacy-peer-deps=true
+strict-ssl=true
+audit-level=high


### PR DESCRIPTION
## Supply-chain hardening: commit a hardened `.npmrc`

Flagged by the weekly `.npmrc` audit ([PER-8328](https://browserstack.atlassian.net/browse/PER-8328) / [SC-12282](https://browserstack.atlassian.net/browse/SC-12282)). `.npmrc` was gitignored because it carried a GitHub Packages token.

**Changes:** committed `.npmrc` sources the token from `${NODE_AUTH_TOKEN}` (no secret committed) and `.npmrc` is un-ignored. The same safe directives were added to **`.npmrc.config`** so the CI-generated `.npmrc` (`cp .npmrc.config .npmrc`) stays consistent.

Added **safe** directives only: `strict-ssl=true`, `save-exact=true` (already present), `audit-level=high`. Held back `ignore-scripts`/`engine-strict` (break installs/CI). `legacy-peer-deps=true` left as-is (repo relies on it).

Ref: [Tech Spec](https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6091571922/Supply+Chain+Security+Enhancements+Tech+Spec)

[PER-8328]: https://browserstack.atlassian.net/browse/PER-8328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-12282]: https://browserstack.atlassian.net/browse/SC-12282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ