### PR TITLE
security: serialize Percy builds with an in-flight guard (PER-8546)

### DIFF
--- a/src/server/snapshots.cjs
+++ b/src/server/snapshots.cjs
@@ -164,9 +164,28 @@ async function runPercyBuild(channel, { baseUrl, include = [], exclude = [] }) {
 
 /* ─── Channel handlers ─────────────────────────────────────────────────── */
 
+// Serialize Percy builds. runPercyBuild mutates shared globals
+// (process.env.PERCY_TOKEN) and the .env file, so firing it concurrently for
+// rapid RUN_SNAPSHOT events races on that state, corrupts the token mid-build,
+// and spawns multiple billable builds (CWE-362). An in-flight guard rejects a
+// second trigger until the running build finishes.
+let buildRunning = false;
+
 function registerSnapshotHandlers(channel) {
-  channel.on(PERCY_EVENTS.RUN_SNAPSHOT, (data) => {
-    runPercyBuild(channel, data);
+  channel.on(PERCY_EVENTS.RUN_SNAPSHOT, async (data) => {
+    if (buildRunning) {
+      channel.emit(PERCY_EVENTS.SNAPSHOT_ERROR, {
+        message: 'A Percy build is already in progress. Please wait for it to finish before starting another.'
+      });
+      return;
+    }
+
+    buildRunning = true;
+    try {
+      await runPercyBuild(channel, data);
+    } finally {
+      buildRunning = false;
+    }
   });
 }
 

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -2736,5 +2736,27 @@ describe('Server / snapshots.cjs', () => {
 
       expect(channel.emit).toHaveBeenCalledWith(PERCY_EVENTS.SNAPSHOT_STARTED, {});
     });
+
+    it('rejects a concurrent RUN_SNAPSHOT while a build is in progress (PER-8546)', async () => {
+      registerSnapshotHandlers(channel);
+      fs.existsSync.and.returnValue(false);
+
+      // Fire two triggers without awaiting the first: the second observes the
+      // in-flight guard and is rejected instead of starting a second build.
+      let first = channel.trigger(PERCY_EVENTS.RUN_SNAPSHOT, { baseUrl: 'http://localhost:6006' });
+      let second = channel.trigger(PERCY_EVENTS.RUN_SNAPSHOT, { baseUrl: 'http://localhost:6006' });
+      await Promise.all([first, second]);
+
+      expect(channel.emit).toHaveBeenCalledWith(
+        PERCY_EVENTS.SNAPSHOT_ERROR,
+        jasmine.objectContaining({ message: jasmine.stringContaining('already in progress') })
+      );
+
+      // a later trigger (after the first finished) is allowed through again
+      channel.emit.calls.reset();
+      await channel.trigger(PERCY_EVENTS.RUN_SNAPSHOT, { baseUrl: 'http://localhost:6006' });
+      await new Promise(r => setTimeout(r, 20));
+      expect(channel.emit).toHaveBeenCalledWith(PERCY_EVENTS.SNAPSHOT_STARTED, {});
+    });
   });
 });


### PR DESCRIPTION
## Summary
Resolves [PER-8546](https://browserstack.atlassian.net/browse/PER-8546) (**High**, CWE-362, deadline 2026-06-16) and the concurrent-build leg of chain [PER-8634](https://browserstack.atlassian.net/browse/PER-8634).

## Problem
`registerSnapshotHandlers` fired `runPercyBuild()` for every `RUN_SNAPSHOT` event **with no `await` and no concurrency guard** (`snapshots.cjs:168`). Rapid events spawned N simultaneous Percy builds that race on shared globals (`process.env.PERCY_TOKEN`) and the `.env` file — corrupting the token mid-build and burning N× the comparison/CI quota billed to the org.

## Fix
Added a module-level `buildRunning` guard:
- set it before `runPercyBuild`, clear it in a `finally`;
- a `RUN_SNAPSHOT` received while a build is in flight is rejected with `SNAPSHOT_ERROR` (*"A Percy build is already in progress…"*) instead of starting a second build.

Serializing builds also eliminates the concurrent `process.env.PERCY_TOKEN` mutation race.

## Verification
`yarn`'s jasmine suite (`registerSnapshotHandlers` + handler-registration specs) passes, including a new test that:
- fires two `RUN_SNAPSHOT` triggers without awaiting the first → asserts the second is rejected with *"already in progress"*;
- confirms a later trigger (after the first completes) is allowed through (`SNAPSHOT_STARTED`).

Closes PER-8546; mitigates the concurrent-build leg of PER-8634 (the IDOR/credential leg of that chain is tracked with PER-8544).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8546]: https://browserstack.atlassian.net/browse/PER-8546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8634]: https://browserstack.atlassian.net/browse/PER-8634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ