### PR TITLE
security: validate credentials before persisting project config (PER-8545 / F-015)

### DIFF
--- a/src/server/projectConfig.cjs
+++ b/src/server/projectConfig.cjs
@@ -276,18 +276,24 @@ function registerProjectConfigHandlers(channel) {
       });
       return;
     }
-    // Clear stale build reference — new project means old build is irrelevant
-    try {
-      let envContent = readEnvRaw();
-      envContent = setKey(envContent, 'PERCY_LAST_TRIGGER_BUILD', '');
-      writeEnvRaw(envContent);
-    } catch (err) {
-      console.warn('Failed to clear last build reference:', err.message);
-    }
 
-    writePercyYml(projectId, projectName);
+    // Validate the credentials/project access by fetching the Percy token FIRST.
+    // Only persist .percy.yml, PERCY_TOKEN and clear the build reference AFTER
+    // validation succeeds — otherwise an unvalidated (or foreign) payload could
+    // redirect future snapshots and overwrite the token before the credentials
+    // are proven good (PER-8545 / F-015).
     fetchPercyToken(projectId, username, accessKey)
       .then(percyToken => {
+        // Clear stale build reference — new project means old build is irrelevant
+        try {
+          let envContent = readEnvRaw();
+          envContent = setKey(envContent, 'PERCY_LAST_TRIGGER_BUILD', '');
+          writeEnvRaw(envContent);
+        } catch (err) {
+          console.warn('Failed to clear last build reference:', err.message);
+        }
+
+        writePercyYml(projectId, projectName);
         setPercyToken(percyToken);
         channel.emit(PERCY_EVENTS.PROJECT_CONFIG_SAVED, { success: true });
       })

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -2484,6 +2484,10 @@ describe('Server / projectConfig.cjs', () => {
           projectId: 42, projectName: 'P'
         });
 
+        // build reference is now cleared only AFTER the token fetch validates
+        // the credentials (PER-8545 / F-015), so wait for the async fetch
+        await new Promise(r => setTimeout(r, 50));
+
         // Check that writeEnvRaw was called to clear the build reference
         const writeCalls = fs.writeFileSync.calls.allArgs();
         const envWrites = writeCalls.filter(c => c[0].endsWith('.env'));


### PR DESCRIPTION
## Summary
Addresses the **F-015** leg of [PER-8545](https://browserstack.atlassian.net/browse/PER-8545) (**High**, CWE-306/CWE-287, deadline 2026-06-16).

## Problem
`SAVE_PROJECT_CONFIG` wrote `.percy.yml`, cleared `PERCY_LAST_TRIGGER_BUILD`, and (via the token fetch) overwrote `PERCY_TOKEN` **before** the supplied credentials were validated. An unvalidated or foreign payload could thus redirect future snapshots and clobber local config/token before the credentials were proven good.

## Fix
Reorder `projectConfig.cjs`: `fetchPercyToken()` (which validates the credentials + project access) now runs **first**; `.percy.yml`, `PERCY_TOKEN`, and the build-reference clear happen **only inside the success `.then()`**. On validation failure, nothing is persisted.

## Verification
All 6 `SAVE_PROJECT_CONFIG` jasmine specs pass (success, missing-creds, session-only payload, token-fetch-failure, build-ref-clear, clear-failure-tolerated). The build-ref-clear test was updated to await the now-post-validation async write.

## Scope note
This is the contained F-015 fix only. The **chain-breaker** for PER-8545 — gating every privileged `experimental_serverChannel` handler (`SAVE_BS_CREDENTIALS`, `SET_SESSION_CREDENTIALS`, `SAVE_PROJECT_CONFIG`, `RUN_SNAPSHOT`, build mutations) on a **startup-generated nonce injected into the manager bundle** (or an equivalent origin/CSRF check) — is a larger coordinated change to the manager↔server channel protocol and is tracked as a follow-up on the ticket. Likewise PER-8544 (move account credentials server-side behind a proxy) needs the third-party review-viewer to support proxied auth.

Partially addresses PER-8545 (F-015 done; channel-nonce chain-breaker flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8545]: https://browserstack.atlassian.net/browse/PER-8545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ