### PR TITLE
ci: expose built percy on PATH in CLI-branch injection (PER-9772)

### DIFF
--- a/.github/workflows/test-storybook-v10.yml
+++ b/.github/workflows/test-storybook-v10.yml
@@ -61,8 +61,13 @@ jobs:
           yarn
           yarn build
           yarn global:link
+          # Expose the freshly built `percy` on PATH — yarn link symlinks the
+          # package but not its bin, so `npx percy` would miss it and download
+          # the unrelated public `percy`.
+          echo "$(yarn global bin)" >> "$GITHUB_PATH"
+          export PATH="$(yarn global bin):$PATH"
           cd "$GITHUB_WORKSPACE_PATH"
           yarn link `echo $PERCY_PACKAGES`
-          npx percy --version
+          percy --version
 
       - run: yarn test:coverage


### PR DESCRIPTION
Same inject-resolution fix as the other SDKs: `npx percy` couldn't resolve the yarn-linked `@percy/cli` → downloaded the public `percy`. Add the built CLI bin to PATH + verify with `percy --version`. Applied to `test-storybook-v10.yml` (the workflow the cli sdk-regression fan-out now dispatches). Part of PER-9772. 🤖 Generated with [Claude Code](https://claude.com/claude-code)