### PR TITLE
release-10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/storybook",
-  "version": "10.0.1-beta.4",
+  "version": "10.0.1",
   "description": "Storybook addons for visual testing with Percy",
   "keywords": [
     "storybook",
@@ -19,7 +19,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=22.12"


### PR DESCRIPTION
Stable release **10.0.1** — promotes `10.0.1-beta.4` → `10.0.1` and flips the npm dist-tag `beta` → `latest`. `package.json` only, matching the prior `release-10.0.0` pattern.

Stabilizes the work landed on `master` since v10.0.0, including the merged security fixes:
- axios `1.13.5 → 1.17.0` — clears four High prototype-pollution advisories (#1317)
- serialize Percy builds with an in-flight guard (#1319)
- validate credentials before persisting project config (#1320)
- supply-chain hardened `.npmrc` (#1313, #1316) + Semgrep/CI action pinning

Merging then publishing the GitHub Release `v10.0.1` triggers the npm publish workflow.