### PR TITLE
fix: bound the storyRendered wait so a dropped render event can't hang the CLI (PER-10287)

### DIFF
--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -255,6 +255,17 @@ function needsFreshPage(previousStory) {
   return previousStory && (previousStory.type === 'docs' || hasContaminatingState(previousStory));
 }
 
+// How long to wait for Storybook's render event before giving up on a story.
+// The wait is evaluated in the page and awaited over CDP, which has no timeout
+// of its own, so this deadline is the only thing standing between a dropped
+// render event and a CLI that hangs until CI kills it (PER-10287).
+export const DEFAULT_STORY_RENDER_TIMEOUT = 30000;
+
+function storyRenderTimeout() {
+  let configured = parseInt(process.env.PERCY_STORY_RENDER_TIMEOUT, 10);
+  return configured > 0 ? configured : DEFAULT_STORY_RENDER_TIMEOUT;
+}
+
 // Process a single story and capture its DOM
 async function* processStory(page, story, previewResource, percy, flags, log) {
   // Extract story details
@@ -268,7 +279,9 @@ async function* processStory(page, story, previewResource, percy, flags, log) {
   } else {
     log.debug(`Loading story: ${options.name}`);
     // when not dry-running and javascript is not enabled, capture the story dom
-    let renderResult = yield page.eval(evalSetCurrentStory, { id, args, globals, queryParams });
+    let renderResult = yield page.eval(evalSetCurrentStory, {
+      id, args, globals, queryParams, renderTimeout: storyRenderTimeout()
+    });
     // A play function threw but we still snapshot — warn so the user understands the
     // snapshot may not reflect the interaction (e.g. a click that never landed).
     if (renderResult?.playError) {
@@ -348,6 +361,12 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
         log.debug(`Fresh page needed for story "${currentStory.name}" - previous story had contaminating state`);
       }
 
+      // One page serves many stories, so this has to be a live reference: the
+      // story that fails is whichever one the inner loop is on, not the one the
+      // page was opened with. Reporting the batch's first story here sent a
+      // previous investigation looking at the wrong component (PER-10287).
+      let pageArgs = { snapshotName: snapshots[0].name };
+
       try {
         // Use a single page for as many stories as possible until a context error occurs
         // Only id and viewMode are needed here — args/globals are applied via evalSetCurrentStory channel events
@@ -356,6 +375,7 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
           while (snapshots.length) {
             try {
               let currentStory = snapshots[0];
+              pageArgs.snapshotName = currentStory.name;
 
               // If we need a fresh page for state reset, break out to create a new page
               if (needsNewPage && snapshots.length < initialSnapshotsCount) {
@@ -390,7 +410,7 @@ export async function* takeStorybookSnapshots(percy, callback, { baseUrl, flags 
               throw storyError;
             }
           }
-        }, undefined, { snapshotName: snapshots[0].name });
+        }, undefined, pageArgs);
       } catch (pageError) {
         // Check if the error is an execution context destruction
         if (pageError.isExecutionContextDestroyed) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -352,7 +352,8 @@ export function evalSetCurrentStory({ waitFor }, story) {
     'Storybook object not found on the window. ' +
       'Open Storybook and check the console for errors.'
   ))).then(channel => {
-    let { id, queryParams, globals, args } = story;
+    let { id, queryParams, globals, args, renderTimeout } = story;
+    renderTimeout = renderTimeout || 30000;
 
     // emit a series of events to render the desired story
     channel.emit('setCurrentStory', { storyId: id });
@@ -367,7 +368,28 @@ export function evalSetCurrentStory({ waitFor }, story) {
       // We still resolve and snapshot the story — the failure is surfaced, not blocking.
       let playError = null;
 
+      // Deadline on the render event. Storybook can drop `storyRendered`
+      // entirely — most commonly when the preview page reloads itself during
+      // the transition (a story chunk that boots its own router does this) —
+      // and the events below are the only things that ever settle this
+      // promise. It is awaited over CDP with `awaitPromise: true`, which has
+      // NO protocol-level timeout, so an unbounded wait here hangs the whole
+      // CLI process silently: the build is never finalized and is force-closed
+      // by the server hours later. Reject instead, so `withPage` retries the
+      // story on a fresh page. See PER-10287.
+      let deadline = setTimeout(() => {
+        reject(new Error(
+          `Timed out after ${renderTimeout}ms waiting for Storybook to render "${id}". ` +
+          'The preview page may have reloaded during the transition, or the story never ' +
+          'finished rendering. Raise PERCY_STORY_RENDER_TIMEOUT if the story is genuinely slow.'
+        ));
+      }, renderTimeout);
+
       const handleRendered = () => {
+        // The render arrived — from here on every remaining wait is bounded by
+        // waitForLoadersToDisappear's own 15s cap, so drop the deadline rather
+        // than let it fire on a story that did render.
+        clearTimeout(deadline);
         // After the story/docs is rendered, add a small delay before checking loaders
         // This helps ensure that any post-render loader state changes have time to occur
         setTimeout(() => {
@@ -376,12 +398,17 @@ export function evalSetCurrentStory({ waitFor }, story) {
         }, 100);
       };
 
+      const handleFailed = (err, fallback) => {
+        clearTimeout(deadline);
+        reject(err || new Error(fallback));
+      };
+
       channel.on('storyRendered', handleRendered);
       channel.on('docsRendered', handleRendered);
 
-      channel.on('storyMissing', (err) => reject(err || new Error('Story Missing')));
-      channel.on('storyErrored', (err) => reject(err || new Error('Story Errored')));
-      channel.on('storyThrewException', (err) => reject(err || new Error('Story Threw Exception')));
+      channel.on('storyMissing', (err) => handleFailed(err, 'Story Missing'));
+      channel.on('storyErrored', (err) => handleFailed(err, 'Story Errored'));
+      channel.on('storyThrewException', (err) => handleFailed(err, 'Story Threw Exception'));
 
       // A failing `play` function (e.g. a thrown assertion or an interaction that
       // never lands) is reported by Storybook on these channels rather than as a

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -866,6 +866,36 @@ describe('evalSetCurrentStory event handling', () => {
     setTimeout(() => channel.emit('docsRendered'), 0);
     await expectAsync(promise).toBeResolved();
   });
+
+  // Storybook can drop the render event entirely — most often when the preview
+  // page reloads itself during the transition. This promise is awaited over CDP
+  // with `awaitPromise: true`, which never times out, so without a deadline the
+  // whole CLI hangs and the build is never finalized (PER-10287).
+  it('rejects when no render event ever arrives', async () => {
+    patchNoLoaders();
+    const promise = utils.evalSetCurrentStory({ waitFor }, {
+      id: 'never-renders', renderTimeout: 50
+    });
+    await expectAsync(promise).toBeRejectedWithError(/Timed out after 50ms.*never-renders/s);
+  });
+
+  it('does not time out a story that did render', async () => {
+    patchNoLoaders();
+    const promise = utils.evalSetCurrentStory({ waitFor }, {
+      id: 'renders-late', renderTimeout: 300
+    });
+    setTimeout(() => channel.emit('storyRendered'), 150);
+    await expectAsync(promise).toBeResolved();
+  });
+
+  it('reports a story error rather than waiting out the deadline', async () => {
+    patchNoLoaders();
+    const promise = utils.evalSetCurrentStory({ waitFor }, {
+      id: 'errors', renderTimeout: 10000
+    });
+    setTimeout(() => channel.emit('storyErrored'), 0);
+    await expectAsync(promise).toBeRejectedWithError('Story Errored');
+  });
 });
 
 // ============ Doc Rule Matching Helpers ============


### PR DESCRIPTION
Fixes [PER-10287](https://browserstack.atlassian.net/browse/PER-10287) — "Percy visual tests are stalling intermittently when run in CI pipeline".

## Symptom

Storybook builds stall mid-run with **no error, no timeout, no output**. The CLI process stays alive and completely idle until CI kills it. Server-side the build is never finalized, so the reaper force-closes it — the customer's builds all landed within a minute of exactly **8h00m**, while the actual render work had finished in 1–10 minutes.

A re-run usually passes, which is why this read as flaky infrastructure.

## Root cause

`evalSetCurrentStory` (`src/utils.js`) waits for Storybook's `storyRendered` / `docsRendered` event on a promise with **no deadline** — those channel events are the only things that ever settle it.

That promise is awaited over CDP:

- `@percy/core` `page.js` — `Page.eval` sends `Runtime.callFunctionOn` with `awaitPromise: true`
- `@percy/core` `session.js` — `Session.send` resolves only when the browser replies; **no timeout anywhere**

So if Storybook never emits the render event, **Chrome never sends a response and the CLI blocks forever**, silently. Verified directly over raw CDP: a `Runtime.evaluate` on a never-settling in-page promise produces no response at all, indefinitely.

The event does get lost in practice. Reproduced from the reported Storybook build: the run always stalls on the first story of a chunk that bundles Next.js's router. Loading that chunk makes Next call `window.location.reload()`, and CDP shows the preview page hard-reloading exactly at that transition:

```
Page.frameScheduledNavigation  reason=reload  url=.../iframe.html?id=<story>&viewMode=story
Page.frameRequestedNavigation  reason=reload
Page.frameNavigated            (new loaderId)
```

Whether the run survives is a race:

| reload lands… | CDP result | outcome |
|---|---|---|
| while the eval is in flight | rejects `Inspected target navigated or closed` | `withPage` retries the story → **build completes** |
| otherwise | no response, ever | **CLI hangs until CI kills it** |

Both branches appear in the customer's own logs — the passing runs show the retry, the stalling runs show the last line as `Loading story: <name>` and then nothing. `[percy:monitoring] Stopped monitoring system metrics` fires 5 minutes later (`MONITOR_ACTIVITY_TIMEOUT`), confirming zero queue activity rather than slow work.

`storybook.waitForTimeout` does not help here — it is a per-snapshot option consumed during asset discovery, not a bound on the story transition.

## Fix

Give the render wait a deadline and reject on expiry, so the **existing** `withPage` retry handles it — the same retry that already recovers the racing case today.

- Default 30s, override with `PERCY_STORY_RENDER_TIMEOUT` (ms).
- The deadline is cleared as soon as the render event arrives, so a story that did render is never falsely timed out; from that point every remaining wait is already bounded by `waitForLoadersToDisappear`'s own 15s cap.
- Story-failure events (`storyMissing` / `storyErrored` / `storyThrewException`) clear it too.

Also: the retry warning named the wrong story. `withPage`'s args object was built once per page and carried the batch's **first** story name, so `Retrying Story: <name>` pointed at a component several stories away from the actual failure — which sent the original investigation looking at the wrong component. It now names the story the loop is actually on.

## Testing

New specs in `test/utils.test.js` covering the unbounded-wait case:

- rejects when no render event ever arrives
- does not time out a story that did render (render arrives inside the deadline)
- a story error still rejects immediately rather than waiting out the deadline

```
Executed 125 of 125 specs SUCCESS   # utils + snapshots + unit
```

`test/storybook.test.js` could not run in this environment — its `beforeAll` needs a prepared Storybook fixture. It fails identically on a clean checkout, so it is unaffected by this change.

End-to-end against the reported Storybook build:

- `PERCY_STORY_RENDER_TIMEOUT=50` → every story times out, `withPage` retries twice, CLI **exits 1 with a clear error** instead of hanging
- default timeout → all 13 stories captured, build finalized, exit 0, no spurious timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PER-10287]: https://browserstack.atlassian.net/browse/PER-10287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ