### PR TITLE
release-10.0.1-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/storybook",
-  "version": "10.0.1",
+  "version": "10.0.1-beta.5",
   "description": "Storybook addons for visual testing with Percy",
   "keywords": [
     "storybook",
@@ -19,7 +19,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=22.12"


### PR DESCRIPTION
Version bump only — `10.0.1` → `10.0.1-beta.5`, `publishConfig.tag` → `beta`.

## Why a beta off the 10.0.1 line

`10.0.1` was bumped in #1329 but never tagged or published — npm `latest` is still `10.0.0` and `beta` is `10.0.1-beta.4`. Two commits have landed since that bump and neither is on npm in any form, so they ship here under the `beta` tag and `10.0.1` stays free for the stable cut.

## Included since 10.0.1-beta.4 (#1311)

- #1354 — `fix: bound the storyRendered wait so a dropped render event can't hang the CLI` (PER-10287). Gives `evalSetCurrentStory`'s render wait a 30s deadline (`PERCY_STORY_RENDER_TIMEOUT`) so a lost `storyRendered` rejects into the existing `withPage` retry instead of blocking the CLI forever. Also fixes `Retrying Story:` naming the batch's first story rather than the story that actually failed.
- #1330 — `security: keep BrowserStack creds server-side + validate/gate privileged server channels` (PER-8544, PER-8545).

## Release steps after merge

`.github/workflows/release.yml` publishes on `release: published`, so merging this alone does not ship anything — cut a `v10.0.1-beta.5` pre-release to trigger `npm publish`.

## Note for anyone testing PER-10287 with this build

The deadline in #1354 covers the case where the render promise never settles in a live page. It does **not** cover the case where the preview page reloads mid-transition: the timer lives inside the page, so a context destruction takes it down with the promise. That shape is still under investigation on PER-10287 — this build is not a complete fix for that ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)