### PR TITLE
security(PER-8631): fail the build on executable content in inlined SVG icons

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -30,6 +30,31 @@ function stubMonorepoImports() {
 }
 
 /**
+ * Executable content has no legitimate place in an icon asset. These SVGs are
+ * read straight from node_modules and inlined into the manager bundle via
+ * dangerouslySetInnerHTML, so a tampered icon package could otherwise ship an
+ * `<svg onload="...">` that runs in the Storybook manager on every page load.
+ * The JSON.stringify below prevents JS-source injection but does NOT strip SVG
+ * event-handler attributes, so check the markup and fail the build instead.
+ */
+const UNSAFE_SVG = [
+  [/\son[a-z]+\s*=/i, 'inline event handler'],
+  [/<\s*script/i, '<script> element'],
+  [/javascript:/i, 'javascript: URL']
+];
+
+function assertInertSvg(svg, id) {
+  for (const [pattern, what] of UNSAFE_SVG) {
+    if (pattern.test(svg)) {
+      throw new Error(
+        `[svg-react] refusing to inline ${id}: contains ${what}. ` +
+        'An icon asset must not carry executable content.'
+      );
+    }
+  }
+}
+
+/**
  * SVG plugin: intercepts .svg imports before Vite's asset pipeline.
  *
  * - review-viewer/assets (browser icons): exported as data-URI strings
@@ -52,6 +77,7 @@ function svgPlugin() {
       }
 
       // design-stack-icons: export as inline React component
+      assertInertSvg(svg, id);
       const escaped = JSON.stringify(svg);
       return `
 import * as React from 'react';


### PR DESCRIPTION
## What

`svgPlugin` in `vite.config.mjs` reads every `.svg` from `node_modules` and inlines the markup verbatim into the manager bundle via `dangerouslySetInnerHTML`. `JSON.stringify` prevents JS-source injection but does **not** strip SVG event-handler attributes, and `<svg onload="…">` *does* fire when inserted through `innerHTML`.

This adds a build-time check: if an icon asset carries an inline event handler, a `<script>` element, or a `javascript:` URL, the build throws instead of inlining it.

26 lines, one file, no new dependencies, no runtime code changed.

## Why assert instead of sanitize

These are build-time assets from a pinned dependency, not user input. Failing the build is the better posture — a compromised icon package breaks the release rather than shipping quietly.

DOMPurify was considered and rejected. `USE_PROFILES: { svg: true }` strips `<use xlink:href>`, `mask`/`clipPath`/`filter` id references, and inline `<style>` — all legitimately used by design-system icons, across ~15 import sites — and it needs two new devDependencies (`dompurify` plus `jsdom` for a DOM in Node). This approach adds none, and legitimate icons compile byte-identical.

Scoped to the inlined branch only. The `review-viewer` branch emits a `data:image/svg+xml` URI consumed via `<img src>`, which cannot execute script, so it keeps zero false-positive surface.

## Verification

`node --check` passes. Logic verified against 12 cases — 6 payloads blocked, 6 legitimate icon constructs allowed:

| Blocked | Allowed |
|---|---|
| `<svg onload="…">` | plain `<path>` + `fill`/`viewBox` |
| `<svg\nonload=…>` (newline-split) | `<use xlink:href="#a">` |
| `<script>` | `mask` + `filter` + `url(#…)` refs |
| `< script>` (space-evaded) | inline `<style>` |
| `xlink:href="javascript:…"` | `opacity` / `transform-origin` |
| `<image onerror=…>` | the current Percy logo attribute set |

That right-hand column is the point of the approach: those are exactly the constructs DOMPurify would have stripped.

Attribute *names* cannot be entity-encoded (the parser reads them raw), so there is no `&#111;nload=` evasion; `\s` covers newlines. No SVG or XML attribute other than an event handler begins with `on`, so false positives are essentially nil.

**Not yet verified — please confirm in CI:** `yarn build` against the real `@browserstack/design-stack-icons@2.8.0` corpus, and `yarn lint`. Both need the private scope installed, which I could not do locally. If a shipped icon trips the assertion, that is a finding worth knowing on its own.
