### PR TITLE
security(PER-8549): validate projectId, escape .percy.yml values, gate the token-bearing read

### DIFF
--- a/src/hooks/useBuildItems.js
+++ b/src/hooks/useBuildItems.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useChannel } from 'storybook/manager-api';
 import { PERCY_EVENTS } from '../constants.js';
+import { withNonce } from '../utils/channelNonce.js';
 
 /* ─── Grouping helpers ───────────────────────────────────────────────── */
 
@@ -95,7 +96,7 @@ export function useBuildItems(buildId, buildMeta) {
     fetchedForRef.current = buildId;
     setLoading(true);
     setError(null);
-    emit(PERCY_EVENTS.FETCH_BUILD_ITEMS, { buildId, meta: buildMeta?.meta || buildMeta });
+    emit(PERCY_EVENTS.FETCH_BUILD_ITEMS, withNonce({ buildId, meta: buildMeta?.meta || buildMeta }));
   }, [buildId]);
 
   // Group items by display name → Percy snapshot name ("Title: Name")
@@ -111,7 +112,7 @@ export function useBuildItems(buildId, buildMeta) {
     setError(null);
     setLoading(true);
     fetchedForRef.current = null;
-    emit(PERCY_EVENTS.FETCH_BUILD_ITEMS, { buildId, meta: buildMeta?.meta || buildMeta });
+    emit(PERCY_EVENTS.FETCH_BUILD_ITEMS, withNonce({ buildId, meta: buildMeta?.meta || buildMeta }));
   };
 
   const reset = () => {

--- a/src/server/channelAuth.cjs
+++ b/src/server/channelAuth.cjs
@@ -15,11 +15,18 @@ const { PERCY_EVENTS, CHANNEL_AUTH } = require('../constants.cjs');
  * server injects only into the legitimate, same-origin manager document (see
  * preset.cjs `managerHead`). A cross-origin page cannot read that document, so
  * it cannot learn the nonce, so its forged events are dropped. Read-only
- * fetch/load events are intentionally left open — they expose no write.
+ * fetch/load events are left open where their response exposes neither a write
+ * nor a secret; a read whose reply carries a credential is gated too (see
+ * PRIVILEGED_EVENTS below).
  */
 
-// State-mutating events that require a valid nonce.
+// Events that require a valid nonce: everything state-mutating, plus the few
+// read events whose RESPONSE carries a secret. FETCH_BUILD_ITEMS is the latter
+// — its BUILD_ITEMS_FETCHED reply includes the project-scoped Percy token as a
+// basic-auth value (review-viewer needs it in the browser), so leaving it open
+// hands that token to any page that can reach the dev-server channel.
 const PRIVILEGED_EVENTS = new Set([
+  PERCY_EVENTS.FETCH_BUILD_ITEMS,
   PERCY_EVENTS.SAVE_BS_CREDENTIALS,
   PERCY_EVENTS.SET_SESSION_CREDENTIALS,
   PERCY_EVENTS.SAVE_PROJECT_CONFIG,

--- a/src/server/projectConfig.cjs
+++ b/src/server/projectConfig.cjs
@@ -5,9 +5,57 @@ const { PERCY_EVENTS } = require('../constants.cjs');
 const { getPercyYmlPath, readEnv, readEnvRaw, setKey, writeEnvRaw } = require('./env.cjs');
 const { readBsCredentials, resolveBsCredentials } = require('./credentials.cjs');
 const { loggedFetch } = require('./apiLogger.cjs');
-const { PERCY_API_BASE, validateBuildId, basicAuth } = require('./utils.cjs');
+const { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth } = require('./utils.cjs');
 
 /* ─── .percy.yml helpers ───────────────────────────────────────────────── */
+
+/**
+ * Serialize a string as a YAML double-quoted scalar.
+ *
+ * projectName comes from the Percy API and may legitimately contain quotes,
+ * colons or '#'. Interpolating it raw produced invalid YAML for those projects
+ * (breaking @percy/config, and with it every later build) and let arbitrary
+ * keys be injected into .percy.yml. Double-quoted style with escapes keeps the
+ * value on a single line, so no new YAML structure can be introduced.
+ */
+function yamlQuote(value) {
+  const str = String(value ?? '');
+  return `"${str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t')}"`;
+}
+
+/**
+ * Decode a YAML scalar as written by `yamlQuote`, while still reading the
+ * unescaped values older versions of this file wrote (and hand-edited plain
+ * scalars), so an existing .percy.yml keeps working.
+ */
+function yamlUnquote(raw) {
+  const str = String(raw ?? '').trim();
+  if (!str.startsWith('"')) {
+    // Legacy or hand-written plain scalar; strip a stray wrapping quote pair.
+    return str.replace(/^"|"$/g, '').trim();
+  }
+  let out = '';
+  for (let i = 1; i < str.length; i++) {
+    const ch = str[i];
+    if (ch === '\\') {
+      const next = str[++i];
+      if (next === 'n') out += '\n';
+      else if (next === 'r') out += '\r';
+      else if (next === 't') out += '\t';
+      else if (next !== undefined) out += next;
+    } else if (ch === '"') {
+      break;
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
 
 /**
  * Read project info from .percy.yml. Returns { id, name } or null.
@@ -18,11 +66,11 @@ function readPercyYml() {
   try {
     const content = fs.readFileSync(ymlPath, 'utf8');
     const idMatch = content.match(/^\s*id:\s*(\d+)\s*$/m);
-    const nameMatch = content.match(/^\s*name:\s*"?([^"\n]+)"?\s*$/m);
+    const nameMatch = content.match(/^\s*name:\s*(.*)$/m);
     if (!idMatch) return null;
     return {
       id: parseInt(idMatch[1], 10),
-      name: nameMatch ? nameMatch[1].trim() : ''
+      name: nameMatch ? yamlUnquote(nameMatch[1]) : ''
     };
   } catch {
     return null;
@@ -34,6 +82,10 @@ function readPercyYml() {
  * Appends or updates the project section without clearing other config.
  */
 function writePercyYml(projectId, projectName) {
+  // Re-validate here as well as at the handler boundary: this is the only place
+  // the id reaches the config file, and an unvalidated value could introduce
+  // extra YAML keys via `id: 1\n  <injected>`.
+  const id = validateProjectId(projectId);
   const ymlPath = getPercyYmlPath();
   let content = '';
 
@@ -41,7 +93,7 @@ function writePercyYml(projectId, projectName) {
     content = fs.readFileSync(ymlPath, 'utf8');
   }
 
-  const projectBlock = `project:\n  id: ${projectId}\n  name: "${projectName}"`;
+  const projectBlock = `project:\n  id: ${id}\n  name: ${yamlQuote(projectName)}`;
 
   // Check if a project section already exists
   const projectSectionRegex = /^project:\s*\n(?:\s+\w[^\n]*\n?)*/m;
@@ -64,9 +116,13 @@ function writePercyYml(projectId, projectName) {
  * Fetch the master Percy token for a project.
  */
 async function fetchPercyToken(projectId, username, accessKey) {
+  // Numeric-guard then encode before interpolation: without this a crafted
+  // projectId can redirect this authenticated request off percy.io, leaking
+  // the BrowserStack access key in the Authorization header.
+  const id = encodeURIComponent(validateProjectId(projectId));
   const token = Buffer.from(`${username}:${accessKey}`).toString('base64');
   const res = await loggedFetch(
-    `https://percy.io/api/v1/projects/${projectId}/tokens`,
+    `https://percy.io/api/v1/projects/${id}/tokens`,
     { headers: { Authorization: `Basic ${token}` } },
     'fetch-percy-token'
   );
@@ -98,7 +154,7 @@ function setPercyToken(token) {
  */
 async function fetchProjectDetails(projectId, username, accessKey) {
   const res = await loggedFetch(
-    `${PERCY_API_BASE}/projects/${projectId}`,
+    `${PERCY_API_BASE}/projects/${encodeURIComponent(validateProjectId(projectId))}`,
     {
       headers: {
         Authorization: `Basic ${basicAuth(username, accessKey)}`,
@@ -280,12 +336,26 @@ function registerProjectConfigHandlers(channel) {
       return;
     }
 
+    // Validate the browser-supplied projectId once, at the boundary, before it
+    // reaches an outbound URL or the config file. The UI only ever sends a
+    // Percy JSON:API id, so this rejects nothing a real client would send.
+    let id;
+    try {
+      id = validateProjectId(projectId);
+    } catch {
+      channel.emit(PERCY_EVENTS.PROJECT_CONFIG_SAVED, {
+        success: false,
+        error: 'Invalid project selected'
+      });
+      return;
+    }
+
     // Validate the credentials/project access by fetching the Percy token FIRST.
     // Only persist .percy.yml, PERCY_TOKEN and clear the build reference AFTER
     // validation succeeds — otherwise an unvalidated (or foreign) payload could
     // redirect future snapshots and overwrite the token before the credentials
     // are proven good (PER-8545 / F-015).
-    fetchPercyToken(projectId, username, accessKey)
+    fetchPercyToken(id, username, accessKey)
       .then(percyToken => {
         // Clear stale build reference — new project means old build is irrelevant
         try {
@@ -296,7 +366,7 @@ function registerProjectConfigHandlers(channel) {
           console.warn('Failed to clear last build reference:', err.message);
         }
 
-        writePercyYml(projectId, projectName);
+        writePercyYml(id, projectName);
         setPercyToken(percyToken);
         channel.emit(PERCY_EVENTS.PROJECT_CONFIG_SAVED, { success: true });
       })

--- a/src/server/utils.cjs
+++ b/src/server/utils.cjs
@@ -13,8 +13,24 @@ function validateBuildId(raw) {
   return id;
 }
 
+/**
+ * Validate projectId is a numeric string.
+ *
+ * projectId arrives from the browser on SAVE_PROJECT_CONFIG and is interpolated
+ * both into a Percy API URL and into .percy.yml, so an unvalidated value allows
+ * an outbound request to be redirected off percy.io and arbitrary keys to be
+ * injected into the config file.
+ */
+function validateProjectId(raw) {
+  const id = String(raw ?? '');
+  if (!/^\d{1,20}$/.test(id)) {
+    throw new Error('Invalid projectId: must be numeric');
+  }
+  return id;
+}
+
 function basicAuth(username, accessKey) {
   return Buffer.from(`${username}:${accessKey}`).toString('base64');
 }
 
-module.exports = { PERCY_API_BASE, validateBuildId, basicAuth };
+module.exports = { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth };

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -2180,6 +2180,17 @@ describe('Server / projectConfig.cjs', () => {
       fs.readFileSync.and.returnValue('project:\n  id: 42\n  name: Legacy Project');
       expect(readPercyYml()).toEqual({ id: 42, name: 'Legacy Project' });
     });
+    it('decodes \r and \t escapes in the name', () => {
+      fs.existsSync.and.returnValue(true);
+      fs.readFileSync.and.returnValue('project:\n  id: 42\n  name: "a\\rb\\tc"');
+      expect(readPercyYml()).toEqual({ id: 42, name: 'a\rb\tc' });
+    });
+
+    it('tolerates a truncated trailing escape in the name', () => {
+      fs.existsSync.and.returnValue(true);
+      fs.readFileSync.and.returnValue('project:\n  id: 42\n  name: "abc\\');
+      expect(readPercyYml()).toEqual({ id: 42, name: 'abc' });
+    });
   });
 
   describe('writePercyYml', () => {
@@ -2234,6 +2245,13 @@ describe('Server / projectConfig.cjs', () => {
       const content = fs.writeFileSync.calls.mostRecent().args[1];
       expect(content).toContain('name: "ok\\nadditionalSnapshots: evil"');
       expect(content).not.toMatch(/^\s*additionalSnapshots:/m);
+    });
+
+    it('writes an empty quoted name when projectName is missing', () => {
+      fs.existsSync.and.returnValue(false);
+      writePercyYml(7);
+      const content = fs.writeFileSync.calls.mostRecent().args[1];
+      expect(content).toContain('name: ""');
     });
 
     it('escapes backslashes in the project name', () => {
@@ -2702,6 +2720,25 @@ describe('Server / projectConfig.cjs', () => {
     });
 
     describe('SAVE_PROJECT_CONFIG', () => {
+      it('rejects a non-numeric projectId without touching disk or network', async () => {
+        fs.existsSync.and.returnValue(true);
+        fs.readFileSync.and.callFake((p) => {
+          if (p.endsWith('.env')) return 'BROWSERSTACK_USERNAME=u\nBROWSERSTACK_ACCESS_KEY=k';
+          return '';
+        });
+        globalThis.fetch = jasmine.createSpy('fetch');
+
+        await channel.trigger(PERCY_EVENTS.SAVE_PROJECT_CONFIG, {
+          projectId: '1/tokens?x=#@attacker.example.com/', projectName: 'P'
+        });
+
+        expect(channel.emit).toHaveBeenCalledWith(
+          PERCY_EVENTS.PROJECT_CONFIG_SAVED,
+          { success: false, error: 'Invalid project selected' }
+        );
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+      });
       it('writes .percy.yml, fetches token, emits success', async () => {
         fs.existsSync.and.returnValue(true);
         fs.readFileSync.and.callFake((p) => {

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { PERCY_EVENTS, CHANNEL_AUTH } from '../src/constants.cjs';
 import { CHANNEL_AUTH as CHANNEL_AUTH_ESM } from '../src/constants.js';
 import * as preset from '../preset.cjs';
-import { PERCY_API_BASE, validateBuildId, basicAuth } from '../src/server/utils.cjs';
+import { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth } from '../src/server/utils.cjs';
 import { withNonce, getPercyNonce } from '../src/utils/channelNonce.js';
 import {
   getEnvPath, getPercyYmlPath, parseEnv, setKey,
@@ -93,6 +93,31 @@ describe('Server / utils.cjs', () => {
 
     it('throws on strings exceeding 20 digits', () => {
       expect(() => validateBuildId('123456789012345678901')).toThrowError('Invalid buildId: must be numeric');
+    });
+  });
+
+  describe('validateProjectId', () => {
+    it('returns the id for a numeric string', () => {
+      expect(validateProjectId('42')).toBe('42');
+    });
+
+    it('accepts a number', () => {
+      expect(validateProjectId(42)).toBe('42');
+    });
+
+    it('rejects a path-traversal / SSRF payload', () => {
+      expect(() => validateProjectId('1/tokens?x=#@attacker.example.com/'))
+        .toThrowError(/Invalid projectId/);
+    });
+
+    it('rejects a newline payload', () => {
+      expect(() => validateProjectId('1\n  evil: x')).toThrowError(/Invalid projectId/);
+    });
+
+    it('rejects empty and nullish input', () => {
+      expect(() => validateProjectId('')).toThrowError(/Invalid projectId/);
+      expect(() => validateProjectId(undefined)).toThrowError(/Invalid projectId/);
+      expect(() => validateProjectId(null)).toThrowError(/Invalid projectId/);
     });
   });
 
@@ -2143,6 +2168,18 @@ describe('Server / projectConfig.cjs', () => {
       fs.readFileSync.and.throwError('read error');
       expect(readPercyYml()).toBe(null);
     });
+
+    it('decodes an escaped name written by writePercyYml', () => {
+      fs.existsSync.and.returnValue(true);
+      fs.readFileSync.and.returnValue('project:\n  id: 42\n  name: "My \\"DS\\""');
+      expect(readPercyYml()).toEqual({ id: 42, name: 'My "DS"' });
+    });
+
+    it('still reads a legacy unquoted name', () => {
+      fs.existsSync.and.returnValue(true);
+      fs.readFileSync.and.returnValue('project:\n  id: 42\n  name: Legacy Project');
+      expect(readPercyYml()).toEqual({ id: 42, name: 'Legacy Project' });
+    });
   });
 
   describe('writePercyYml', () => {
@@ -2182,6 +2219,34 @@ describe('Server / projectConfig.cjs', () => {
       const content = fs.writeFileSync.calls.mostRecent().args[1];
       expect(content).toContain('version: 2');
       expect(content).toContain('project:');
+    });
+
+    it('escapes a project name containing double quotes', () => {
+      fs.existsSync.and.returnValue(false);
+      writePercyYml(7, 'My "Design System"');
+      const content = fs.writeFileSync.calls.mostRecent().args[1];
+      expect(content).toContain('name: "My \\"Design System\\""');
+    });
+
+    it('keeps an injected newline on one line so no YAML keys can be added', () => {
+      fs.existsSync.and.returnValue(false);
+      writePercyYml(7, 'ok\nadditionalSnapshots: evil');
+      const content = fs.writeFileSync.calls.mostRecent().args[1];
+      expect(content).toContain('name: "ok\\nadditionalSnapshots: evil"');
+      expect(content).not.toMatch(/^\s*additionalSnapshots:/m);
+    });
+
+    it('escapes backslashes in the project name', () => {
+      fs.existsSync.and.returnValue(false);
+      writePercyYml(7, 'back\\slash');
+      const content = fs.writeFileSync.calls.mostRecent().args[1];
+      expect(content).toContain('name: "back\\\\slash"');
+    });
+
+    it('rejects a non-numeric projectId instead of writing it', () => {
+      fs.existsSync.and.returnValue(false);
+      expect(() => writePercyYml('1\n  evil: x', 'N')).toThrowError(/Invalid projectId/);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });
 
@@ -3129,7 +3194,10 @@ describe('Server / channelAuth.cjs', () => {
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.REJECT_BUILD)).toBe(true);
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.DELETE_BUILD)).toBe(true);
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.MERGE_BUILD)).toBe(true);
-      // read-only fetch/load events stay open
+      // FETCH_BUILD_ITEMS is a read, but its reply carries the project-scoped
+      // Percy token, so it is gated too.
+      expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.FETCH_BUILD_ITEMS)).toBe(true);
+      // read-only events that expose no secret stay open
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.LOAD_BS_CREDENTIALS)).toBe(false);
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.FETCH_BUILD_STATUS)).toBe(false);
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.FETCH_PROJECTS)).toBe(false);


### PR DESCRIPTION
Finishes the remaining live findings from the security batch. The chain tickets (C-001..C-004) were closed on their chain-breakers, but these three were still reachable in code.

## 1. `projectId` SSRF (F-014)

`projectId` arrives from the browser on `SAVE_PROJECT_CONFIG` and was interpolated raw into `https://percy.io/api/v1/projects/${projectId}/tokens` — a crafted value could redirect that **authenticated** request off `percy.io`, leaking the BrowserStack access key in the `Authorization` header.

Now validated numerically at the handler boundary, and `encodeURIComponent`'d before interpolation as defence in depth. Zero functional impact: every caller passes a Percy JSON:API `id`, which is always a numeric string (`percyApi.cjs` `p.id`, `CreateProject.jsx` `json.data.id`).

## 2. `.percy.yml` injection (F-010) — also a live functional bug

`projectName` went into `name: "${projectName}"` raw, allowing arbitrary YAML keys (`additionalSnapshots`, `widths`, include/exclude) to be injected.

**This was breaking real users too.** A project legitimately named `My "Design System"` produced `name: "My "DS""` → invalid YAML → `@percy/config` load failure → every subsequent build fails.

Values are now written as properly escaped YAML double-quoted scalars, which keeps them on a single line so no structure can be introduced.

**Escaped, not rejected — deliberately.** The ticket's remediation says to reject `"`, `\n`, `\r`, `\\` in `projectName`; that would lock out anyone whose Percy project name contains a quote. `readPercyYml` is updated in the same change, because its old regex (`/^\s*name:\s*"?([^"\n]+)"?\s*$/m`) cannot read an escaped value — a writer-only fix would have silently broken project restore on startup. It still reads legacy unquoted values, so existing `.percy.yml` files keep working.

`projectId` is validated inside `writePercyYml` as well, since `id:` was interpolated raw too (`id: 1\n  <injected>`).

## 3. Token-bearing read was left ungated

`FETCH_BUILD_ITEMS` was excluded from `PRIVILEGED_EVENTS` on the grounds that it is a read — but its `BUILD_ITEMS_FETCHED` reply carries the project-scoped Percy token as a basic-auth value. Any page able to reach the dev-server channel could request it with no nonce. Now gated, with `withNonce` added at both manager call sites (`useBuildItems.js:99` and `:115`).

**Not implemented as the ticket words it.** C-001's remediation says "remove `authToken` from all browser-facing channel emits" — `@browserstack/review-viewer` makes its own direct percy.io calls and needs that token in the browser (`ReviewPage.jsx:260` is `{authToken && selectedSnapshotId ? …}`, so the review panel renders nothing without it). Gating the *request* is the equivalent fix without killing the feature.

## Verification

`node --check` clean on every changed file. `yamlQuote`/`yamlUnquote` round-trip verified against the real functions for 8 inputs including `My "Design System"`, `a: b # c`, `ok\nadditionalSnapshots: evil` (escapes to one line, no key injected), backslashes, tabs, single quotes and emoji — plus legacy-read compatibility for `"My Project"`, `My Project` and whitespace-padded values.

**+16 tests**: 5 for `validateProjectId` (incl. the ticket's exact SSRF payload `1/tokens?x=#@attacker.example.com/` and a newline payload), 4 for `writePercyYml` escaping and id rejection, 2 for `readPercyYml` escaped + legacy decode, 1 asserting `FETCH_BUILD_ITEMS` is now gated.

The existing `PRIVILEGED_EVENTS` test has a deliberate "no read-only ones" section; I updated its comment and added the positive assertion rather than leaving a stale claim. No existing assertion had to be weakened — simple names still serialize to `name: "Test"` exactly as before.

⚠️ **I could not run `yarn test` locally** (the private `@browserstack` scope isn't installable in my environment), so the suite is unverified by me — CI will be its first real run. The three round-trip/assertion simulations above were executed against the actual shipped functions, so I'm confident in the logic, but please let CI confirm the jasmine wiring.
