### PR TITLE
security(PER-8628, PER-8630): gate stored-credential reads behind the channel nonce; harden v7/v8 workflows

### DIFF
--- a/.github/workflows/test-storybook-v7.yml
+++ b/.github/workflows/test-storybook-v7.yml
@@ -46,9 +46,12 @@ jobs:
       - run: yarn build
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }} # Store input.branch in an environment variable
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }} # Store github.workspace in an environment variable
         run: |
           cd /tmp
-          git clone --branch ${{ inputs.branch }}  --depth 1 https://github.com/percy/cli
+          git clone --branch "$INPUT_BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -type d -mindepth 1 -maxdepth 1 | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           echo "Packages: $PERCY_PACKAGES"
@@ -56,7 +59,7 @@ jobs:
           yarn
           yarn build
           yarn global:link
-          cd ${{ github.workspace }} 
+          cd "$GITHUB_WORKSPACE_PATH"
           yarn link `echo $PERCY_PACKAGES`
           npx percy --version
 

--- a/.github/workflows/test-storybook-v8.yml
+++ b/.github/workflows/test-storybook-v8.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Break on invalid branch name
         run: exit 1
         if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - uses: actions/checkout@8459bc0c7e3759cdf591f513d9f141a95fef0a8f
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
@@ -51,9 +51,12 @@ jobs:
           npx storybook --version
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }} # Store input.branch in an environment variable
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }} # Store github.workspace in an environment variable
         run: |
           cd /tmp
-          git clone --branch ${{ inputs.branch }}  --depth 1 https://github.com/percy/cli
+          git clone --branch "$INPUT_BRANCH" --depth 1 https://github.com/percy/cli
           cd cli
           PERCY_PACKAGES=`find packages -type d -mindepth 1 -maxdepth 1 | sed -e 's/packages/@percy/g' | tr '\n' ' '`
           echo "Packages: $PERCY_PACKAGES"
@@ -61,7 +64,7 @@ jobs:
           yarn
           yarn build
           yarn global:link
-          cd ${{ github.workspace }} 
+          cd "$GITHUB_WORKSPACE_PATH"
           yarn link `echo $PERCY_PACKAGES`
           npx percy --version
 

--- a/src/components/PercyPanel.jsx
+++ b/src/components/PercyPanel.jsx
@@ -205,6 +205,7 @@ export function PercyPanel({ active }) {
             <ProjectSetup
               username={credentials.username}
               accessKey={credentials.accessKey}
+              storedOnServer={credentials.storedOnServer}
               initialSearch=""
               onProjectConfirmed={(project) => transition('PROJECT_CONFIRMED', project)}
               onCreateProject={() => transition('CREATE_NEW_PROJECT')}

--- a/src/components/PercyPanel.jsx
+++ b/src/components/PercyPanel.jsx
@@ -5,6 +5,7 @@ import DSIBStack from '@browserstack/design-stack-icons/dist/DSIBStack';
 import { useChannel } from 'storybook/manager-api';
 import { useTheme } from 'storybook/theming';
 import { PERCY_EVENTS } from '../constants.js';
+import { withNonce } from '../utils/channelNonce.js';
 import { usePercyPanelState } from '../hooks/usePercyPanelState.js';
 import { useSnapshotChannel } from '../hooks/useSnapshotChannel.js';
 import { useBuildItems } from '../hooks/useBuildItems.js';
@@ -72,7 +73,7 @@ export function PercyPanel({ active }) {
     const id = buildMeta?.buildId;
     if (!id) return;
     // Re-fetch build status to update reviewState in buildMeta
-    emitChannel(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: id });
+    emitChannel(PERCY_EVENTS.FETCH_BUILD_STATUS, withNonce({ buildId: id }));
     // Re-fetch build items to update snapshot-level review states
     retryItems();
   }, [buildMeta?.buildId, emitChannel, retryItems]);

--- a/src/components/ProjectSetup.jsx
+++ b/src/components/ProjectSetup.jsx
@@ -14,10 +14,12 @@ import {
   Divider, CreateLink, LoadingRow
 } from './ProjectSetup.styles.js';
 
-export function ProjectSetup({ username, accessKey, initialSearch, onProjectConfirmed, onCreateProject }) {
+export function ProjectSetup({
+  username, accessKey, storedOnServer = false, initialSearch, onProjectConfirmed, onCreateProject
+}) {
   const {
     projects, loading, initialLoading, hasMore, error, search, setSearch, loadMore, cancel
-  } = usePercyProjects(username, accessKey, initialSearch);
+  } = usePercyProjects(username, accessKey, initialSearch, storedOnServer);
 
   const [selectedProject, setSelectedProject] = useState(null);
   const [saving, setSaving] = useState(false);

--- a/src/components/ReviewPage.jsx
+++ b/src/components/ReviewPage.jsx
@@ -295,7 +295,7 @@ export default function ReviewPage({
                   key={buildId}
                   apiBaseUrl="https://percy.io/api"
                   authToken={authToken}
-                  authType="basic"
+                  authType="token"
                   buildId={buildId}
                   snapshotId={selectedSnapshotId}
                   panels={{ ai: true, comments: true, history: true, regions: true, snapshotRules: true }}

--- a/src/components/ReviewPage.jsx
+++ b/src/components/ReviewPage.jsx
@@ -71,18 +71,26 @@ function ReviewContent({ snapshotId, buildId, onReviewComplete }) {
     setParamsState(prev => ({ ...prev, ...updates }));
   }, []);
 
-  if (isLoading || !snapshotData) {
+  // Error must be checked BEFORE the loading fallback: on a failed request
+  // RTK Query leaves `data` undefined, so `!snapshotData` alone would render
+  // the loader forever and swallow the failure.
+  if (error) {
+    const status = error?.status ?? error?.originalStatus;
+    const detail = error?.data?.errors?.[0]?.detail || error?.data?.message || error?.error || '';
     return (
-      <div className="flex items-center justify-center h-full">
-        <LoaderV2 size="medium" showLabel label="Loading snapshot..." />
+      <div className="flex flex-col items-center justify-center h-full gap-1 p-4 text-center">
+        <div className="text-sm text-danger-default">
+          Failed to load snapshot{status ? ` (${status})` : ''}
+        </div>
+        {detail && <div className="text-xs text-neutral-500 break-all">{String(detail)}</div>}
       </div>
     );
   }
 
-  if (error) {
+  if (isLoading || !snapshotData) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-sm text-danger-default">Failed to load snapshot</div>
+        <LoaderV2 size="medium" showLabel label="Loading snapshot..." />
       </div>
     );
   }

--- a/src/hooks/useBuildPolling.js
+++ b/src/hooks/useBuildPolling.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useChannel, useStorybookApi } from 'storybook/manager-api';
 import { PERCY_EVENTS, BUILD_STATES, PANEL_ID } from '../constants.js';
+import { withNonce } from '../utils/channelNonce.js';
 
 const POLL_INTERVAL_MS = 10000;
 const TIME_UPDATE_INTERVAL_MS = 60000;
@@ -92,12 +93,12 @@ export function useBuildPolling(buildId) {
         timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
         return;
       }
-      emit(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: buildIdRef.current });
+      emit(PERCY_EVENTS.FETCH_BUILD_STATUS, withNonce({ buildId: buildIdRef.current }));
       timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
     };
 
     // Immediate first fetch
-    emit(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId });
+    emit(PERCY_EVENTS.FETCH_BUILD_STATUS, withNonce({ buildId }));
     timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
 
     return () => { canceled = true; clearTimeout(timeoutId); };
@@ -131,7 +132,7 @@ export function useBuildPolling(buildId) {
   const downloadLogs = () => {
     if (logDownload.loading) return;
     setLogDownload({ loading: true, error: null });
-    emit(PERCY_EVENTS.FETCH_BUILD_LOGS, { buildId });
+    emit(PERCY_EVENTS.FETCH_BUILD_LOGS, withNonce({ buildId }));
   };
 
   return {

--- a/src/hooks/usePercyPanelState.js
+++ b/src/hooks/usePercyPanelState.js
@@ -20,7 +20,7 @@ const VIEWS = {
  */
 export function usePercyPanelState() {
   const [view, setView] = useState(VIEWS.INITIALIZING);
-  const [credentials, setCredentials] = useState({ username: '', accessKey: '' });
+  const [credentials, setCredentials] = useState({ username: '', accessKey: '', storedOnServer: false });
   const [selectedProject, setSelectedProject] = useState(null);
   const [projectDetails, setProjectDetails] = useState(null);
   const [buildMeta, setBuildMeta] = useState(null);
@@ -44,7 +44,7 @@ export function usePercyPanelState() {
 
       // User actions
       case 'AUTHENTICATED':
-        setCredentials({ username: payload.username, accessKey: payload.accessKey });
+        setCredentials({ username: payload.username, accessKey: payload.accessKey, storedOnServer: false });
         setView(VIEWS.PROJECT_SETUP);
         break;
       case 'PROJECT_CONFIRMED':

--- a/src/hooks/usePercyProjects.js
+++ b/src/hooks/usePercyProjects.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useChannel } from 'storybook/manager-api';
 import { PERCY_EVENTS } from '../constants.js';
+import { withNonce } from '../utils/channelNonce.js';
 
 const DEBOUNCE_MS = 350;
 
@@ -82,12 +83,12 @@ export function usePercyProjects(username, accessKey, initialSearch = '') {
     setLoading(true);
     setError('');
 
-    emit(PERCY_EVENTS.FETCH_PROJECTS, {
+    emit(PERCY_EVENTS.FETCH_PROJECTS, withNonce({
       username,
       accessKey,
       search: debouncedSearch,
       page: 0
-    });
+    }));
   }, [debouncedSearch]); // eslint-disable-line
 
   const loadMore = useCallback(() => {
@@ -95,12 +96,12 @@ export function usePercyProjects(username, accessKey, initialSearch = '') {
     pageRef.current += 1;
 
     setLoading(true);
-    emit(PERCY_EVENTS.FETCH_PROJECTS, {
+    emit(PERCY_EVENTS.FETCH_PROJECTS, withNonce({
       username,
       accessKey,
       search: debouncedSearch,
       page: pageRef.current
-    });
+    }));
   }, [debouncedSearch, username, accessKey]); // eslint-disable-line
 
   const cancel = useCallback(() => {

--- a/src/hooks/usePercyProjects.js
+++ b/src/hooks/usePercyProjects.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useChannel } from 'storybook/manager-api';
 import { PERCY_EVENTS } from '../constants.js';
 import { withNonce } from '../utils/channelNonce.js';
+import { canFetchProjects } from '../utils/credentials.js';
 
 const DEBOUNCE_MS = 350;
 
@@ -12,8 +13,10 @@ const DEBOUNCE_MS = 350;
  * @param {string} username - BrowserStack username
  * @param {string} accessKey - BrowserStack access key
  * @param {string} [initialSearch] - Initial search term
+ * @param {boolean} [storedOnServer] - server holds a validated credential pair,
+ *   so the fetch must fire even though the browser has no access key
  */
-export function usePercyProjects(username, accessKey, initialSearch = '') {
+export function usePercyProjects(username, accessKey, initialSearch = '', storedOnServer = false) {
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
@@ -70,10 +73,12 @@ export function usePercyProjects(username, accessKey, initialSearch = '') {
   // window; it is ignored once the cache is populated.
   //
   // Guard against firing a credential-less request: with no username/access key
-  // on either side the server would attempt basicAuth('', '') and 401. Skip the
-  // fetch entirely until we actually have a client-held pair to send.
+  // on EITHER side the server would attempt basicAuth('', '') and 401. The
+  // server never sends the access key to the browser, so after a startup
+  // restore the client pair is empty while the server pair is valid —
+  // `storedOnServer` covers that case (see canFetchProjects).
   useEffect(() => {
-    if (!username || !accessKey) {
+    if (!canFetchProjects(username, accessKey, storedOnServer)) {
       setLoading(false);
       setInitialLoading(false);
       return;
@@ -89,7 +94,7 @@ export function usePercyProjects(username, accessKey, initialSearch = '') {
       search: debouncedSearch,
       page: 0
     }));
-  }, [debouncedSearch]); // eslint-disable-line
+  }, [debouncedSearch, storedOnServer]); // eslint-disable-line
 
   const loadMore = useCallback(() => {
     if (loadingRef.current || !hasMoreRef.current) return;

--- a/src/hooks/useSnapshotChannel.js
+++ b/src/hooks/useSnapshotChannel.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useChannel, useStorybookApi } from 'storybook/manager-api';
 import { PERCY_EVENTS, SNAPSHOT_STATUS } from '../constants.js';
+import { credentialsFromConfigLoaded } from '../utils/credentials.js';
 import { getCurrentStory } from '../utils/storybookApi.js';
 
 /**
@@ -23,13 +24,10 @@ export function useSnapshotChannel(transition, view, VIEWS) {
     [PERCY_EVENTS.PROJECT_CONFIG_LOADED]: ({ credentialsValid, username, accessKey, project, projectDetails, hasValidToken, lastBuild }) => {
       configLoaded.current = true;
       // The server validated its stored pair but (deliberately) does not send
-      // the access key to the browser. Flag it so credential-dependent views
-      // (project picker) know a fetch will succeed server-side.
-      const creds = {
-        username: username || '',
-        accessKey: accessKey || '',
-        storedOnServer: !!credentialsValid
-      };
+      // the access key to the browser; credentialsFromConfigLoaded flags it so
+      // credential-dependent views (project picker) know a fetch will succeed
+      // server-side.
+      const creds = credentialsFromConfigLoaded({ credentialsValid, username, accessKey });
 
       if (!credentialsValid) {
         transition('RESTORE_NONE');

--- a/src/hooks/useSnapshotChannel.js
+++ b/src/hooks/useSnapshotChannel.js
@@ -22,7 +22,14 @@ export function useSnapshotChannel(transition, view, VIEWS) {
   const emit = useChannel({
     [PERCY_EVENTS.PROJECT_CONFIG_LOADED]: ({ credentialsValid, username, accessKey, project, projectDetails, hasValidToken, lastBuild }) => {
       configLoaded.current = true;
-      const creds = { username: username || '', accessKey: accessKey || '' };
+      // The server validated its stored pair but (deliberately) does not send
+      // the access key to the browser. Flag it so credential-dependent views
+      // (project picker) know a fetch will succeed server-side.
+      const creds = {
+        username: username || '',
+        accessKey: accessKey || '',
+        storedOnServer: !!credentialsValid
+      };
 
       if (!credentialsValid) {
         transition('RESTORE_NONE');

--- a/src/hooks/useSnapshotDetail.js
+++ b/src/hooks/useSnapshotDetail.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useChannel } from 'storybook/manager-api';
 import { PERCY_EVENTS } from '../constants.js';
+import { withNonce } from '../utils/channelNonce.js';
 
 /**
  * Fetches snapshot detail (denormalized JSON:API) via server channel.
@@ -40,7 +41,7 @@ export function useSnapshotDetail(snapshotId) {
     activeIdRef.current = String(snapshotId);
     setIsLoading(true);
     setError(null);
-    emit(PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, { snapshotId });
+    emit(PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, withNonce({ snapshotId }));
   }, [snapshotId]);
 
   const refetch = useCallback(() => {
@@ -48,7 +49,7 @@ export function useSnapshotDetail(snapshotId) {
     activeIdRef.current = String(snapshotId);
     setIsLoading(true);
     setError(null);
-    emit(PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, { snapshotId });
+    emit(PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, withNonce({ snapshotId }));
   }, [snapshotId, emit]);
 
   return { snapshot, entities, isLoading, error, refetch };

--- a/src/server/buildItems.cjs
+++ b/src/server/buildItems.cjs
@@ -70,8 +70,11 @@ function registerBuildItemsHandlers(channel) {
 
       // Only the project-scoped Percy token (written to .env during project
       // setup) may be handed to the browser for review-viewer's direct percy.io
-      // calls. It is sent as a basic-auth value (token as username, empty
-      // password). Never send the BrowserStack username/access key.
+      // calls. It is sent RAW: review-viewer presents it as
+      // `Authorization: Token token=<value>` (authType="token"), which is the
+      // only scheme percy.io accepts for a project token — HTTP Basic is
+      // reserved for BrowserStack username/access-key pairs and 401s otherwise.
+      // Never send the BrowserStack username/access key.
       const percyToken = readEnv().PERCY_TOKEN;
 
       const payload = {
@@ -79,7 +82,7 @@ function registerBuildItemsHandlers(channel) {
         items: json.data || [],
         filters: json.meta?.filters || null
       };
-      if (percyToken) payload.authToken = basicAuth(percyToken, '');
+      if (percyToken) payload.authToken = percyToken;
 
       channel.emit(PERCY_EVENTS.BUILD_ITEMS_FETCHED, payload);
     } catch (err) {

--- a/src/server/channelAuth.cjs
+++ b/src/server/channelAuth.cjs
@@ -14,19 +14,33 @@ const { PERCY_EVENTS, CHANNEL_AUTH } = require('../constants.cjs');
  * The gate: every STATE-MUTATING event must carry a per-process nonce that the
  * server injects only into the legitimate, same-origin manager document (see
  * preset.cjs `managerHead`). A cross-origin page cannot read that document, so
- * it cannot learn the nonce, so its forged events are dropped. Read-only
- * fetch/load events are left open where their response exposes neither a write
- * nor a secret; a read whose reply carries a credential is gated too (see
+ * it cannot learn the nonce, so its forged events are dropped. Only the
+ * startup/load events whose response exposes neither a write nor anything read
+ * with the developer's stored credentials are left open (see
  * PRIVILEGED_EVENTS below).
  */
 
-// Events that require a valid nonce: everything state-mutating, plus the few
-// read events whose RESPONSE carries a secret. FETCH_BUILD_ITEMS is the latter
-// — its BUILD_ITEMS_FETCHED reply includes the project-scoped Percy token as a
-// basic-auth value (review-viewer needs it in the browser), so leaving it open
-// hands that token to any page that can reach the dev-server channel.
+// Events that require a valid nonce: everything state-mutating, plus every read
+// that is served with the developer's STORED BrowserStack credentials.
+//
+//  - FETCH_BUILD_ITEMS: its BUILD_ITEMS_FETCHED reply includes the
+//    project-scoped Percy token as a basic-auth value (review-viewer needs it in
+//    the browser), so leaving it open hands that token to any page that can
+//    reach the dev-server channel.
+//  - FETCH_PROJECTS: enumerates every Percy project the stored account can see.
+//  - FETCH_BUILD_STATUS / FETCH_BUILD_LOGS / FETCH_SNAPSHOT_DETAIL: take a
+//    caller-chosen numeric id and read it with the stored credentials, i.e. an
+//    IDOR read against any build/snapshot the account can reach (CWE-639).
+//
+// Left open on purpose: LOAD_BS_CREDENTIALS and LOAD_PROJECT_CONFIG (startup
+// state for the panel; neither returns a secret) and VALIDATE_CREDENTIALS (only
+// ever checks the pair the caller itself supplied).
 const PRIVILEGED_EVENTS = new Set([
   PERCY_EVENTS.FETCH_BUILD_ITEMS,
+  PERCY_EVENTS.FETCH_PROJECTS,
+  PERCY_EVENTS.FETCH_BUILD_STATUS,
+  PERCY_EVENTS.FETCH_BUILD_LOGS,
+  PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL,
   PERCY_EVENTS.SAVE_BS_CREDENTIALS,
   PERCY_EVENTS.SET_SESSION_CREDENTIALS,
   PERCY_EVENTS.SAVE_PROJECT_CONFIG,

--- a/src/utils/credentials.js
+++ b/src/utils/credentials.js
@@ -1,0 +1,23 @@
+/**
+ * Percy Storybook Addon – manager-side credential predicates (pure, no React).
+ */
+
+/**
+ * Whether the project picker may fire FETCH_PROJECTS.
+ *
+ * The server prefers its own stored credentials (.env or the validated session
+ * cache) and, since the F-017 fix, never sends the access key back to the
+ * browser. So after a startup restore or "Change project" the browser holds
+ * NO access key while the server holds a validated one — the fetch must still
+ * fire in that case. The client-held pair is only required when the server
+ * has nothing yet (the first-time / session-only flow), where it is sent as the
+ * fallback the server uses before its cache is seeded.
+ *
+ * @param {string} username        client-held BrowserStack username ('' if none)
+ * @param {string} accessKey       client-held BrowserStack access key ('' if none)
+ * @param {boolean} storedOnServer server reported a validated stored pair
+ */
+export function canFetchProjects(username, accessKey, storedOnServer) {
+  if (storedOnServer) return true;
+  return !!(username && accessKey);
+}

--- a/src/utils/credentials.js
+++ b/src/utils/credentials.js
@@ -21,3 +21,22 @@ export function canFetchProjects(username, accessKey, storedOnServer) {
   if (storedOnServer) return true;
   return !!(username && accessKey);
 }
+
+/**
+ * Build the panel's credentials object from a PROJECT_CONFIG_LOADED payload.
+ *
+ * The server validates its stored pair on startup and reports only
+ * `credentialsValid` — it deliberately does not send the access key back to
+ * the browser (F-017). `storedOnServer` carries that fact forward so
+ * credential-dependent views (project picker) know a fetch will succeed
+ * server-side even though the client pair is empty.
+ *
+ * @param {{ credentialsValid?: boolean, username?: string, accessKey?: string }} payload
+ */
+export function credentialsFromConfigLoaded({ credentialsValid, username, accessKey } = {}) {
+  return {
+    username: username || '',
+    accessKey: accessKey || '',
+    storedOnServer: !!credentialsValid
+  };
+}

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,5 +1,5 @@
 import { validateStoryArgs, encodeStoryArgs, decodeStoryArgs } from '../src/utils.js';
-import { canFetchProjects } from '../src/utils/credentials.js';
+import { canFetchProjects, credentialsFromConfigLoaded } from '../src/utils/credentials.js';
 
 describe('Unit /', () => {
   describe('canFetchProjects', () => {
@@ -22,6 +22,33 @@ describe('Unit /', () => {
       expect(canFetchProjects('user', '', false)).toBe(false);
       expect(canFetchProjects('', 'key', false)).toBe(false);
       expect(canFetchProjects(undefined, undefined, undefined)).toBe(false);
+    });
+  });
+
+  describe('credentialsFromConfigLoaded', () => {
+    it('flags server-held credentials on a valid restore even though no key is sent', () => {
+      // This is exactly what the server emits after F-017: valid, no secret.
+      expect(credentialsFromConfigLoaded({ credentialsValid: true, project: null, hasValidToken: false }))
+        .toEqual({ username: '', accessKey: '', storedOnServer: true });
+    });
+
+    it('does not flag server-held credentials when the server says they are invalid', () => {
+      expect(credentialsFromConfigLoaded({ credentialsValid: false }))
+        .toEqual({ username: '', accessKey: '', storedOnServer: false });
+      expect(credentialsFromConfigLoaded({}))
+        .toEqual({ username: '', accessKey: '', storedOnServer: false });
+      expect(credentialsFromConfigLoaded())
+        .toEqual({ username: '', accessKey: '', storedOnServer: false });
+    });
+
+    it('preserves a username the server chooses to send, normalising nullish to empty string', () => {
+      expect(credentialsFromConfigLoaded({ credentialsValid: true, username: 'u', accessKey: null }))
+        .toEqual({ username: 'u', accessKey: '', storedOnServer: true });
+    });
+
+    it('restored credentials always allow the project picker to fetch', () => {
+      const c = credentialsFromConfigLoaded({ credentialsValid: true });
+      expect(canFetchProjects(c.username, c.accessKey, c.storedOnServer)).toBe(true);
     });
   });
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,6 +1,30 @@
 import { validateStoryArgs, encodeStoryArgs, decodeStoryArgs } from '../src/utils.js';
+import { canFetchProjects } from '../src/utils/credentials.js';
 
 describe('Unit /', () => {
+  describe('canFetchProjects', () => {
+    // Regression: after the server stopped sending the access key to the
+    // browser (F-017), a startup restore or "Change project" left the picker
+    // with an empty client pair and it silently never fetched — every search
+    // showed "No result found" while creating a project still worked.
+    it('fires when the server holds a validated stored pair, even with no client key', () => {
+      expect(canFetchProjects('', '', true)).toBe(true);
+      expect(canFetchProjects('user', '', true)).toBe(true);
+    });
+
+    it('fires when the browser holds a complete pair (first-time / session-only flow)', () => {
+      expect(canFetchProjects('user', 'key', false)).toBe(true);
+      expect(canFetchProjects('user', 'key', undefined)).toBe(true);
+    });
+
+    it('does not fire a credential-less request when neither side has a pair', () => {
+      expect(canFetchProjects('', '', false)).toBe(false);
+      expect(canFetchProjects('user', '', false)).toBe(false);
+      expect(canFetchProjects('', 'key', false)).toBe(false);
+      expect(canFetchProjects(undefined, undefined, undefined)).toBe(false);
+    });
+  });
+
   describe('validateStoryArgs', () => {
     it('returns false when the key is empty or invalid', () => {
       expect(validateStoryArgs(null, 'value')).toBe(false);

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -5,6 +5,7 @@ import { CHANNEL_AUTH as CHANNEL_AUTH_ESM, PERCY_EVENTS as PERCY_EVENTS_ESM } fr
 import * as preset from '../preset.cjs';
 import { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth } from '../src/server/utils.cjs';
 import { withNonce, getPercyNonce } from '../src/utils/channelNonce.js';
+import { canFetchProjects, credentialsFromConfigLoaded } from '../src/utils/credentials.js';
 import {
   getEnvPath, getPercyYmlPath, parseEnv, setKey,
   readEnv, readEnvRaw, writeEnvRaw
@@ -977,6 +978,33 @@ describe('Server / percyApi.cjs', () => {
   });
 
   describe('FETCH_PROJECTS', () => {
+    it('serves a payload with NO credentials from the stored .env pair (post-restore picker)', async () => {
+      // After a startup restore the browser holds no access key (F-017), so the
+      // picker emits FETCH_PROJECTS with empty client credentials and relies on
+      // the server's stored pair. This is the request shape the fix in
+      // usePercyProjects/canFetchProjects now lets through.
+      fs.readFileSync.and.callFake((p) => (
+        p.endsWith('.env') ? 'BROWSERSTACK_USERNAME=stored-u\nBROWSERSTACK_ACCESS_KEY=stored-k' : ''
+      ));
+      globalThis.fetch = jasmine.createSpy('fetch').and.resolveTo(mockResponse({
+        data: [{ id: '9', attributes: { name: 'Restored' } }]
+      }));
+
+      await channel.trigger(PERCY_EVENTS.FETCH_PROJECTS, {
+        username: '', accessKey: '', search: '', page: 0
+      });
+
+      const [url, opts] = globalThis.fetch.calls.mostRecent().args;
+      expect(url).toContain('/projects?');
+      expect(opts.headers.Authorization).toBe(`Basic ${basicAuth('stored-u', 'stored-k')}`);
+      expect(channel.emit).toHaveBeenCalledWith(
+        PERCY_EVENTS.PROJECTS_FETCHED,
+        jasmine.objectContaining({
+          projects: [{ id: '9', name: 'Restored', updatedAt: '' }], search: '', page: 0
+        })
+      );
+    });
+
     it('emits projects on success', async () => {
       const json = {
         data: [
@@ -2393,6 +2421,23 @@ describe('Server / projectConfig.cjs', () => {
         const loaded = channel.emit.calls.mostRecent().args[1];
         expect(loaded.username).toBeUndefined();
         expect(loaded.accessKey).toBeUndefined();
+
+        // Cross-wire contract: this exact payload, run through the manager's
+        // restore helper, must still let the project picker fetch. This is the
+        // regression where F-017 removed the key but the picker's guard kept
+        // requiring it, so "Change project" silently listed nothing.
+        const creds = credentialsFromConfigLoaded(loaded);
+        expect(creds).toEqual({ username: '', accessKey: '', storedOnServer: true });
+        expect(canFetchProjects(creds.username, creds.accessKey, creds.storedOnServer)).toBe(true);
+      });
+
+      it('an invalid-credentials payload does not let the picker fetch server-side', async () => {
+        fs.existsSync.and.returnValue(false);
+        await channel.trigger(PERCY_EVENTS.LOAD_PROJECT_CONFIG);
+        const loaded = channel.emit.calls.mostRecent().args[1];
+        const creds = credentialsFromConfigLoaded(loaded);
+        expect(creds.storedOnServer).toBe(false);
+        expect(canFetchProjects(creds.username, creds.accessKey, creds.storedOnServer)).toBe(false);
       });
 
       it('auto-fetches token when project exists but PERCY_TOKEN is missing', async () => {
@@ -3388,6 +3433,49 @@ describe('Server / channelAuth.cjs', () => {
         PERCY_EVENTS.UNAUTHORIZED, { event: PERCY_EVENTS.CREATE_PROJECT }
       );
     });
+  });
+});
+
+/* ═══════════════════════════════════════════════════════════════════════ */
+/*  Manager wiring contracts (source-level guards)                          */
+/* ═══════════════════════════════════════════════════════════════════════ */
+
+// The manager is React and there is no DOM/component test infrastructure in
+// this repo, so these guard the two wiring contracts that the manual e2e run
+// found broken, at the source level — the same approach as the withNonce scan.
+describe('Manager / wiring contracts', () => {
+  const read = (p) => fs.readFileSync(p, 'utf8');
+
+  it('review-viewer is given the project token with the Token scheme, never Basic', () => {
+    // percy.io accepts a project token ONLY as `Authorization: Token token=…`;
+    // HTTP Basic is reserved for BrowserStack username/access-key pairs and
+    // 401s with "No user found for BrowserStack credentials." otherwise.
+    const reviewPage = read('src/components/ReviewPage.jsx');
+    expect(reviewPage).toContain('authType="token"');
+    expect(reviewPage).not.toContain('authType="basic"');
+    // …and the server must hand over the raw token, not a Basic encoding of it.
+    const buildItems = read('src/server/buildItems.cjs');
+    expect(buildItems).toContain('payload.authToken = percyToken');
+    expect(buildItems).not.toMatch(/basicAuth\(\s*percyToken/);
+  });
+
+  it('server-held credentials are threaded from the restore path into the project picker', () => {
+    // useSnapshotChannel -> (credentialsFromConfigLoaded) -> PercyPanel -> ProjectSetup -> usePercyProjects
+    expect(read('src/hooks/useSnapshotChannel.js')).toContain('credentialsFromConfigLoaded({ credentialsValid, username, accessKey })');
+    expect(read('src/components/PercyPanel.jsx')).toContain('storedOnServer={credentials.storedOnServer}');
+    expect(read('src/components/ProjectSetup.jsx')).toMatch(/usePercyProjects\(username,\s*accessKey,\s*initialSearch,\s*storedOnServer\)/);
+    expect(read('src/hooks/usePercyProjects.js')).toContain('canFetchProjects(username, accessKey, storedOnServer)');
+  });
+
+  it('snapshot load errors are checked before the loading fallback', () => {
+    // On a failed request RTK Query leaves `data` undefined; if the loader
+    // branch ran first the failure would render as an endless spinner.
+    const src = read('src/components/ReviewPage.jsx');
+    const errorIdx = src.indexOf('if (error) {');
+    const loadingIdx = src.indexOf('if (isLoading || !snapshotData) {');
+    expect(errorIdx).toBeGreaterThan(-1);
+    expect(loadingIdx).toBeGreaterThan(-1);
+    expect(errorIdx).toBeLessThan(loadingIdx);
   });
 });
 

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -3234,10 +3234,57 @@ describe('Server / channelAuth.cjs', () => {
       // FETCH_BUILD_ITEMS is a read, but its reply carries the project-scoped
       // Percy token, so it is gated too.
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.FETCH_BUILD_ITEMS)).toBe(true);
-      // read-only events that expose no secret stay open
+      // startup/load events that expose no secret and read nothing by
+      // caller-chosen id stay open
       expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.LOAD_BS_CREDENTIALS)).toBe(false);
-      expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.FETCH_BUILD_STATUS)).toBe(false);
-      expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.FETCH_PROJECTS)).toBe(false);
+      expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.LOAD_PROJECT_CONFIG)).toBe(false);
+      expect(PRIVILEGED_EVENTS.has(PERCY_EVENTS.VALIDATE_CREDENTIALS)).toBe(false);
+    });
+
+    // Reads served with the developer's STORED credentials. Ungated, any page
+    // that can reach the dev-server WebSocket could enumerate the account's
+    // projects or read arbitrary builds/snapshots/logs by numeric id.
+    const STORED_CREDENTIAL_READS = [
+      PERCY_EVENTS.FETCH_PROJECTS,
+      PERCY_EVENTS.FETCH_BUILD_STATUS,
+      PERCY_EVENTS.FETCH_BUILD_LOGS,
+      PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL
+    ];
+
+    it('gates every read that is served with the stored credentials', () => {
+      for (const event of STORED_CREDENTIAL_READS) {
+        expect(PRIVILEGED_EVENTS.has(event)).withContext(event).toBe(true);
+      }
+    });
+
+    it('every privileged event emitted from manager code is wrapped in withNonce', () => {
+      // Static parity check between the server gate and the manager bundle: a
+      // privileged emit without withNonce() would be silently dropped by the
+      // server, so the UI would hang on a response that never arrives.
+      const roots = ['src/hooks', 'src/components'];
+      const eventName = Object.fromEntries(
+        Object.entries(PERCY_EVENTS).map(([k, v]) => [v, k])
+      );
+      const privilegedKeys = new Set([...PRIVILEGED_EVENTS].map(v => eventName[v]));
+      const emitRe = /\b(?:emit|emitChannel|channelEmit)\(\s*PERCY_EVENTS\.(\w+)\s*,\s*([^\s(]*)/g;
+      const violations = [];
+      const files = [];
+      for (const root of roots) {
+        for (const f of fs.readdirSync(root)) {
+          if (/\.(js|jsx)$/.test(f)) files.push(path.join(root, f));
+        }
+      }
+      expect(files.length).toBeGreaterThan(0);
+      for (const file of files) {
+        const src = fs.readFileSync(file, 'utf8');
+        for (const m of src.matchAll(emitRe)) {
+          const [, key, nextToken] = m;
+          if (privilegedKeys.has(key) && nextToken !== 'withNonce') {
+            violations.push(`${file}: ${key}`);
+          }
+        }
+      }
+      expect(violations).toEqual([]);
     });
   });
 
@@ -3251,6 +3298,21 @@ describe('Server / channelAuth.cjs', () => {
       guarded.on(PERCY_EVENTS.LOAD_BS_CREDENTIALS, handler);
       channel.trigger(PERCY_EVENTS.LOAD_BS_CREDENTIALS, { foo: 'bar' });
       expect(handler).toHaveBeenCalledWith({ foo: 'bar' });
+    });
+
+    it('gates a stored-credential read exactly like a write', () => {
+      const channel = createMockChannel();
+      const guarded = guardChannel(channel, NONCE);
+      const handler = jasmine.createSpy('status');
+      spyOn(console, 'warn');
+      guarded.on(PERCY_EVENTS.FETCH_BUILD_STATUS, handler);
+      channel.trigger(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10' }); // no nonce
+      expect(handler).not.toHaveBeenCalled();
+      expect(channel.emit).toHaveBeenCalledWith(
+        PERCY_EVENTS.UNAUTHORIZED, { event: PERCY_EVENTS.FETCH_BUILD_STATUS }
+      );
+      channel.trigger(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10', [NONCE_FIELD]: NONCE });
+      expect(handler).toHaveBeenCalledWith({ buildId: '10' });
     });
 
     it('runs a privileged handler when the nonce matches, stripped from payload', () => {
@@ -3425,6 +3487,42 @@ describe('preset.cjs (integration wiring)', () => {
       projectName: 'P', username: 'u', accessKey: 'k', [NONCE_FIELD]: nonce
     });
     expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  // Reads that run with the developer's stored credentials must not be reachable
+  // by a cross-origin page: no nonce -> no upstream request, UNAUTHORIZED emitted.
+  const GATED_READS = [
+    [PERCY_EVENTS.FETCH_PROJECTS, { search: '', page: 0 }, PERCY_EVENTS.PROJECTS_FETCHED],
+    [PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10' }, PERCY_EVENTS.BUILD_STATUS_FETCHED],
+    [PERCY_EVENTS.FETCH_BUILD_LOGS, { buildId: '10' }, PERCY_EVENTS.BUILD_LOGS_FETCHED],
+    [PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, { snapshotId: '100' }, PERCY_EVENTS.SNAPSHOT_DETAIL_FETCHED]
+  ];
+
+  for (const [event, payload, reply] of GATED_READS) {
+    it(`drops ${event} without the nonce: no upstream fetch, no reply, UNAUTHORIZED`, async () => {
+      spyOn(console, 'warn');
+      await preset.experimental_serverChannel(channel);
+      await channel.trigger(event, { ...payload });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(channel.emit).not.toHaveBeenCalledWith(reply, jasmine.anything());
+      expect(channel.emit).toHaveBeenCalledWith(PERCY_EVENTS.UNAUTHORIZED, { event });
+    });
+
+    it(`serves ${event} when the payload carries the nonce`, async () => {
+      await preset.experimental_serverChannel(channel);
+      await channel.trigger(event, { ...payload, [NONCE_FIELD]: nonce });
+      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(channel.emit).not.toHaveBeenCalledWith(PERCY_EVENTS.UNAUTHORIZED, jasmine.anything());
+    });
+  }
+
+  it('leaves the startup load events open (no nonce required)', async () => {
+    await preset.experimental_serverChannel(channel);
+    await channel.trigger(PERCY_EVENTS.LOAD_BS_CREDENTIALS);
+    expect(channel.emit).toHaveBeenCalledWith(
+      PERCY_EVENTS.BS_CREDENTIALS_LOADED, jasmine.anything()
+    );
+    expect(channel.emit).not.toHaveBeenCalledWith(PERCY_EVENTS.UNAUTHORIZED, jasmine.anything());
   });
 
   it('managerHead injects a <meta> whose content is getOrCreateNonce()', () => {

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -1289,9 +1289,12 @@ describe('Server / buildItems.cjs', () => {
         buildId: '123',
         items: json.data,
         filters: json.meta.filters,
-        // Only the project-scoped Percy token is handed to the browser,
-        // encoded as a basic-auth value (token as username, empty password).
-        authToken: basicAuth('web_percytoken', '')
+        // Only the project-scoped Percy token is handed to the browser, RAW,
+        // for review-viewer's `Authorization: Token token=<value>` header.
+        // (percy.io only accepts a project token via the Token scheme; a
+        // basic-auth encoding of it 401s with "No user found for BrowserStack
+        // credentials".)
+        authToken: 'web_percytoken'
       })
     );
     // The account-level BrowserStack credentials must never be sent to the browser.
@@ -1299,6 +1302,7 @@ describe('Server / buildItems.cjs', () => {
     expect(payload.username).toBeUndefined();
     expect(payload.accessKey).toBeUndefined();
     expect(payload.authToken).not.toBe(basicAuth('u', 'k'));
+    expect(payload.authToken).not.toBe(basicAuth('web_percytoken', ''));
   });
 
   it('omits authToken when no PERCY_TOKEN is present', async () => {

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { PERCY_EVENTS, CHANNEL_AUTH } from '../src/constants.cjs';
-import { CHANNEL_AUTH as CHANNEL_AUTH_ESM } from '../src/constants.js';
+import { CHANNEL_AUTH as CHANNEL_AUTH_ESM, PERCY_EVENTS as PERCY_EVENTS_ESM } from '../src/constants.js';
 import * as preset from '../preset.cjs';
 import { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth } from '../src/server/utils.cjs';
 import { withNonce, getPercyNonce } from '../src/utils/channelNonce.js';
@@ -3267,8 +3267,10 @@ describe('Server / channelAuth.cjs', () => {
       );
       const privilegedKeys = new Set([...PRIVILEGED_EVENTS].map(v => eventName[v]));
       const emitRe = /\b(?:emit|emitChannel|channelEmit)\(\s*PERCY_EVENTS\.(\w+)\s*,\s*([^\s(]*)/g;
+      const refRe = /\bPERCY_EVENTS\.(\w+)\b/g;
       const violations = [];
       const files = [];
+      let wrappedEmits = 0;
       for (const root of roots) {
         for (const f of fs.readdirSync(root)) {
           if (/\.(js|jsx)$/.test(f)) files.push(path.join(root, f));
@@ -3277,14 +3279,30 @@ describe('Server / channelAuth.cjs', () => {
       expect(files.length).toBeGreaterThan(0);
       for (const file of files) {
         const src = fs.readFileSync(file, 'utf8');
+        // Every literal emit of a privileged event must be wrapped.
+        const literalEmits = [];
         for (const m of src.matchAll(emitRe)) {
           const [, key, nextToken] = m;
-          if (privilegedKeys.has(key) && nextToken !== 'withNonce') {
-            violations.push(`${file}: ${key}`);
-          }
+          if (!privilegedKeys.has(key)) continue;
+          literalEmits.push(key);
+          if (nextToken !== 'withNonce') violations.push(`${file}: ${key} emitted without withNonce`);
+          else wrappedEmits++;
+        }
+        // Every OTHER reference to a privileged constant (assigned to a variable,
+        // passed through a helper, emitted via a different function name) is
+        // something this scan cannot prove is wrapped, so it fails too.
+        const refs = [...src.matchAll(refRe)].map(m => m[1]).filter(k => privilegedKeys.has(k));
+        if (refs.length !== literalEmits.length) {
+          violations.push(
+            `${file}: ${refs.length} privileged PERCY_EVENTS references but only ` +
+            `${literalEmits.length} recognised literal emit(...) calls`
+          );
         }
       }
       expect(violations).toEqual([]);
+      // Sanity: the scan actually saw the manager's privileged emits (guards
+      // against a refactor that moves files out of the scanned roots).
+      expect(wrappedEmits).toBeGreaterThanOrEqual(privilegedKeys.size);
     });
   });
 
@@ -3378,6 +3396,13 @@ describe('constants — CJS/ESM parity', () => {
     // Both server (cjs) and manager (esm) sides must agree on the nonce field
     // and meta name, or the gate would silently reject every legitimate event.
     expect(CHANNEL_AUTH).toEqual(CHANNEL_AUTH_ESM);
+  });
+
+  it('PERCY_EVENTS is identical across the CJS and ESM constants', () => {
+    // The manager emits the ESM names and the server gates the CJS names. If
+    // a privileged event's string diverged, the gate would drop every
+    // legitimate emit of it and the UI would hang on a reply that never comes.
+    expect(PERCY_EVENTS).toEqual(PERCY_EVENTS_ESM);
   });
 });
 
@@ -3491,14 +3516,36 @@ describe('preset.cjs (integration wiring)', () => {
 
   // Reads that run with the developer's stored credentials must not be reachable
   // by a cross-origin page: no nonce -> no upstream request, UNAUTHORIZED emitted.
+  // [event, payload, reply event, upstream response, url fragment proving the
+  //  payload id reached the handler intact, expected reply shape]
   const GATED_READS = [
-    [PERCY_EVENTS.FETCH_PROJECTS, { search: '', page: 0 }, PERCY_EVENTS.PROJECTS_FETCHED],
-    [PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10' }, PERCY_EVENTS.BUILD_STATUS_FETCHED],
-    [PERCY_EVENTS.FETCH_BUILD_LOGS, { buildId: '10' }, PERCY_EVENTS.BUILD_LOGS_FETCHED],
-    [PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, { snapshotId: '100' }, PERCY_EVENTS.SNAPSHOT_DETAIL_FETCHED]
+    [
+      PERCY_EVENTS.FETCH_PROJECTS, { search: 'Proj', page: 2 }, PERCY_EVENTS.PROJECTS_FETCHED,
+      { data: [{ id: '1', attributes: { name: 'Proj A', 'updated-at': '2024-01-01' } }] },
+      'filter%5Bsearch%5D=Proj',
+      { projects: [{ id: '1', name: 'Proj A', updatedAt: '2024-01-01' }], hasMore: false, search: 'Proj', page: 2 }
+    ],
+    [
+      PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10' }, PERCY_EVENTS.BUILD_STATUS_FETCHED,
+      { data: { attributes: { state: 'finished', 'build-number': 3, branch: 'main' } } },
+      '/builds/10?',
+      jasmine.objectContaining({ buildId: '10', state: 'finished', buildNumber: 3, headBranch: 'main' })
+    ],
+    [
+      PERCY_EVENTS.FETCH_BUILD_LOGS, { buildId: '10' }, PERCY_EVENTS.BUILD_LOGS_FETCHED,
+      'line 1\nline 2',
+      'build_id=10',
+      { content: 'line 1\nline 2', filename: 'percy-build-10.log' }
+    ],
+    [
+      PERCY_EVENTS.FETCH_SNAPSHOT_DETAIL, { snapshotId: '100' }, PERCY_EVENTS.SNAPSHOT_DETAIL_FETCHED,
+      { data: { id: '100', type: 'snapshots', attributes: { name: 'Snap' } } },
+      '/snapshots/100?',
+      jasmine.objectContaining({ snapshotId: '100', data: jasmine.objectContaining({ id: '100', name: 'Snap' }) })
+    ]
   ];
 
-  for (const [event, payload, reply] of GATED_READS) {
+  for (const [event, payload, reply, upstream, urlFragment, expectedReply] of GATED_READS) {
     it(`drops ${event} without the nonce: no upstream fetch, no reply, UNAUTHORIZED`, async () => {
       spyOn(console, 'warn');
       await preset.experimental_serverChannel(channel);
@@ -3508,13 +3555,45 @@ describe('preset.cjs (integration wiring)', () => {
       expect(channel.emit).toHaveBeenCalledWith(PERCY_EVENTS.UNAUTHORIZED, { event });
     });
 
-    it(`serves ${event} when the payload carries the nonce`, async () => {
+    it(`drops ${event} with a forged nonce`, async () => {
+      spyOn(console, 'warn');
+      await preset.experimental_serverChannel(channel);
+      await channel.trigger(event, { ...payload, [NONCE_FIELD]: 'forged-' + nonce });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(channel.emit).toHaveBeenCalledWith(PERCY_EVENTS.UNAUTHORIZED, { event });
+    });
+
+    it(`serves ${event} end-to-end when the payload carries the nonce`, async () => {
+      globalThis.fetch.and.resolveTo(mockResponse(upstream));
       await preset.experimental_serverChannel(channel);
       await channel.trigger(event, { ...payload, [NONCE_FIELD]: nonce });
-      expect(globalThis.fetch).toHaveBeenCalled();
+
+      // The gate stripped the nonce and forwarded the rest of the payload
+      // intact: the upstream request carries the caller's id / search.
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(globalThis.fetch.calls.mostRecent().args[0]).toContain(urlFragment);
+      // ...and the handler produced its normal, correct reply.
+      expect(channel.emit).toHaveBeenCalledWith(reply, expectedReply);
       expect(channel.emit).not.toHaveBeenCalledWith(PERCY_EVENTS.UNAUTHORIZED, jasmine.anything());
     });
   }
+
+  it('a stale nonce from a previous process is rejected on a polled read', async () => {
+    // Dev-server restart without a manager reload: the manager keeps emitting
+    // the OLD nonce on every FETCH_BUILD_STATUS poll. Each poll must be
+    // rejected (so nothing runs on the stored credentials) and each must
+    // emit UNAUTHORIZED so PercyPanel can show the recovery screen.
+    spyOn(console, 'warn');
+    const stale = generateNonce();
+    expect(stale).not.toBe(nonce);
+    await preset.experimental_serverChannel(channel);
+    for (let i = 0; i < 3; i++) {
+      await channel.trigger(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10', [NONCE_FIELD]: stale });
+    }
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    const unauthorized = channel.emit.calls.allArgs().filter(a => a[0] === PERCY_EVENTS.UNAUTHORIZED);
+    expect(unauthorized.length).toBe(3);
+  });
 
   it('leaves the startup load events open (no nonce required)', async () => {
     await preset.experimental_serverChannel(channel);


### PR DESCRIPTION
## Summary

Closes the two residuals recorded in the closing comments of the C-001 (PER-8628) and C-003 (PER-8630) chain tickets. Both tickets are already Closed; this finishes what those comments flagged as still live.

### PER-8628 residual — reads served with the stored credentials were ungated
`FETCH_PROJECTS`, `FETCH_BUILD_STATUS`, `FETCH_BUILD_LOGS` and `FETCH_SNAPSHOT_DETAIL` ran with the developer's stored BrowserStack credentials but required no nonce, so any page that could reach the dev-server WebSocket could enumerate the account's Percy projects or read arbitrary builds/snapshots/logs by numeric id (CWE-639, the read half of F-004).

- Added the four events to `PRIVILEGED_EVENTS` in `src/server/channelAuth.cjs`.
- Every manager call site now passes `withNonce()`: `usePercyProjects` (2), `useBuildPolling` (3), `useSnapshotDetail` (2), `PercyPanel` post-approve refresh (1).
- `LOAD_BS_CREDENTIALS`, `LOAD_PROJECT_CONFIG`, `VALIDATE_CREDENTIALS` stay open on purpose: none returns a secret or reads by caller-chosen id.
- UX: a stale nonce (dev-server restarted, manager not reloaded) now surfaces the existing "session expired" recovery screen on the first poll instead of only on the next write.

### PER-8630 residual — v7/v8 workflows still inlined inputs into `run:`
- `test-storybook-v7.yml` / `test-storybook-v8.yml`: copied the v9/v10 env-var pattern verbatim (`"$INPUT_BRANCH"`, `"$GITHUB_WORKSPACE_PATH"`). No functional change.
- `test-storybook-v8.yml`: bumped `actions/checkout` pin to the SHA every other workflow uses (was stale v4.1.1).

### Also fixed here — project picker dead after reload (regression from #1330 / F-017)
Found during the manual e2e run of this branch. `PROJECT_CONFIG_LOADED` correctly stopped sending the access key to the browser in #1330, but `usePercyProjects` kept `if (!username || !accessKey) return`. After a startup restore with saved `.env` credentials, or "Change project", the client pair is empty so the hook silently never emitted `FETCH_PROJECTS`: every search showed "No result found" with no server call, while Create project (server-side credential resolution) still worked.

- Restore path now flags `storedOnServer: credentialsValid` on the credentials object; `ProjectSetup` passes it through.
- Guard is now `canFetchProjects(username, accessKey, storedOnServer)` in `src/utils/credentials.js` (pure, unit-tested): fire when the server holds a validated pair OR the browser holds a complete pair; never when neither does.

### Also fixed here — review panel 401 on every snapshot (regression from #1330 / F-001)
Found during the manual e2e run. Since #1330 `FETCH_BUILD_ITEMS` handed review-viewer `basicAuth(PERCY_TOKEN, '')` with `authType="basic"`. percy.io treats HTTP Basic strictly as a BrowserStack username/access-key pair (`authenticate_via_browserstack_auth`), so every direct snapshot fetch from the panel 401'd with `No user found for BrowserStack credentials.` and the UI sat on "Loading snapshot..." forever.

- Server now sends the raw project-scoped token; `ReviewPage` sets `authType="token"`, so review-viewer sends `Authorization: Token token=<value>` — the only scheme percy.io accepts for a project token (`authenticate_via_token`). Supported by review-viewer since before the pinned 0.1.1.
- `ReviewContent` checked `isLoading || !snapshotData` before `error`, which swallowed the failure. Error is now checked first and shows status + API detail.
- Tests assert the raw token is sent and that neither the account credentials nor the old Basic encoding is.

### Not done, deliberately
The PER-8628 "server-side allowlist of build IDs" bullet would break approving/deleting builds opened from the project list that were not created in this session, and Percy already enforces account-side authorization.

## Tests
- `PRIVILEGED_EVENTS` assertions updated; new test asserting every stored-credential read is gated.
- `guardChannel` test: a gated read is dropped without the nonce and served with it.
- `preset.cjs` integration: for each of the four reads, no nonce ⇒ no upstream fetch, no reply, `UNAUTHORIZED`; nonce ⇒ fetch called. Plus one asserting the load events stay open.
- `canFetchProjects` / `credentialsFromConfigLoaded` unit tests: server-held pair, client-held pair, neither; valid/invalid/legacy restore payloads.
- Server: `FETCH_PROJECTS` with an empty client pair is served from the stored `.env` pair (post-restore picker request shape).
- Cross-wire: the real `PROJECT_CONFIG_LOADED` payload, fed through the manager restore helper, must still let the picker fetch; the invalid payload must not.
- Source guards (no component test infra in this repo): review-viewer uses `authType="token"` and the server hands over the raw token; server-held credentials are threaded through to `usePercyProjects`; `ReviewContent` checks `error` before the loading fallback.
- Static parity scan over `src/hooks` and `src/components`: every emit of a privileged event must be wrapped in `withNonce`, so a future ungated emit fails CI instead of hanging the UI.

Local: syntax checks, YAML validation, and a standalone run of the guard logic + source scan passed. Full Jasmine suite runs in CI (green on every commit).

## Manual e2e
Driven with `e2e-panel.sh` (builds this branch, packs it, installs it into a sandbox copy of example-percy-storybook, starts Storybook against real percy.io). Verified so far: nonce `<meta>` served and readable from the manager document; connect flow; project search (client-held and, after the fix above, server-held credentials); create project; run snapshots; build polling to Finished. The two regressions above were found by this run and fixed; after the fixes the full checklist (snapshot detail, approve, logs, forged and stale nonce) passed. Automating this as a Playwright smoke job against a dev project is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



