### PR TITLE
Release 10.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/storybook",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "Storybook addons for visual testing with Percy",
   "keywords": [
     "storybook",


### PR DESCRIPTION
Version bump 10.0.2 → 10.0.3 (`package.json` only, same shape as #1358).

## Changes since 10.0.2
- #1365 security(PER-8631): fail the build on executable content in inlined SVG icons
- #1367 security(PER-8549): validate projectId, escape .percy.yml values, gate the token-bearing read
- #1373 security(PER-8553): bump lodash to 4.18.1 and force it for every transitive path (build-time devDependency)
- #1372 security(PER-8549, PER-8548, PER-8551): `.env` value validation, query-param key encoding, https-only build URLs, in-flight guard on approve/reject/delete/merge, 60 s cap on `RESPONSIVE_CAPTURE_SLEEP_TIME`
- #1368 security(PER-8628, PER-8630): gate stored-credential reads behind the channel nonce; harden v7/v8 workflows — plus two user-facing fixes: project picker empty after reload with saved credentials, and review panel 401 on every snapshot (project token now sent with the `Token` scheme)

Publish is triggered by the GitHub Release (`release.yml` on `release: published`), so merge this, then cut the `v10.0.3` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

