### PR TITLE
security(PER-8549, PER-8548, PER-8551): close the remaining input-validation, duplicate-action and unbounded-sleep findings

### DIFF
--- a/src/components/BuildProgress.jsx
+++ b/src/components/BuildProgress.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { Button, LoaderV2 } from '@browserstack/design-stack';
 import { MdOutlineOpenInNew } from '@browserstack/design-stack-icons';
 import { BUILD_STATES } from '../constants.js';
+import { safeHttpsUrl } from '../utils/safeUrl.js';
 import { useBuildPolling } from '../hooks/useBuildPolling.js';
 import { InProgressBuild } from './InProgressBuild';
 import { FailedBuild } from './FailedBuild';
@@ -13,7 +14,8 @@ export function BuildProgress({ buildId, buildUrl, buildNumber, snapshotScope, o
     progressPercent, pollError, downloadLogs, logDownload
   } = useBuildPolling(buildId);
 
-  const webUrl = buildData?.webUrl || buildUrl;
+  // Scheme-checked before it reaches href (F-023).
+  const webUrl = safeHttpsUrl(buildData?.webUrl || buildUrl);
   const displayNumber = buildData?.buildNumber || buildNumber;
   const isFailed = state === BUILD_STATES.FAILED;
   const isFinished = state === BUILD_STATES.FINISHED;
@@ -27,7 +29,7 @@ export function BuildProgress({ buildId, buildUrl, buildNumber, snapshotScope, o
       onReviewReady({
         buildId: buildData.buildId || buildId,
         buildNumber: buildData.buildNumber || buildNumber,
-        webUrl: buildData.webUrl || buildUrl,
+        webUrl: safeHttpsUrl(buildData.webUrl || buildUrl),
         reviewState: buildData.reviewState,
         reviewStateReason: buildData.reviewStateReason,
         headBranch: buildData.headBranch,

--- a/src/components/ReviewHeader.jsx
+++ b/src/components/ReviewHeader.jsx
@@ -10,6 +10,7 @@ import { useChannel, useStorybookApi } from 'storybook/manager-api';
 import { useTheme } from 'storybook/theming';
 import { PERCY_EVENTS, SNAPSHOT_TYPES } from '../constants.js';
 import { withNonce } from '../utils/channelNonce.js';
+import { safeHttpsUrl } from '../utils/safeUrl.js';
 import { getReviewStateDisplay, formatDiffPercent } from '../utils/reviewState.js';
 import {
   buildCurrentStoryPattern,
@@ -190,8 +191,10 @@ function KebabMenu({ buildId, webUrl, reviewState, reviewStateReason, projectDet
     }
   });
 
-  const settingsUrl = webUrl
-    ? webUrl.replace(/\/builds\/\d+$/, '/settings')
+  // Scheme-checked before it reaches window.open (F-023).
+  const safeWebUrl = safeHttpsUrl(webUrl);
+  const settingsUrl = safeWebUrl
+    ? safeWebUrl.replace(/\/builds\/\d+$/, '/settings')
     : null;
 
   const isMerged = reviewState === 'merged';
@@ -294,8 +297,8 @@ export default function ReviewHeader({
 
       {/* Right: action buttons */}
       <div className="flex items-center gap-2 flex-shrink-0">
-        {webUrl && (
-          <a href={webUrl} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>
+        {safeHttpsUrl(webUrl) && (
+          <a href={safeHttpsUrl(webUrl)} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>
             <Button variant="secondary" size="small" icon={<MdOutlineOpenInNew />} iconPlacement="end">
               Review in Percy
             </Button>

--- a/src/server/buildApi.cjs
+++ b/src/server/buildApi.cjs
@@ -3,13 +3,41 @@
 const { PERCY_EVENTS } = require('../constants.cjs');
 const { loggedFetch } = require('./apiLogger.cjs');
 const { readBsCredentials } = require('./credentials.cjs');
-const { PERCY_API_BASE, validateBuildId, basicAuth } = require('./utils.cjs');
+const { PERCY_API_BASE, validateBuildId, basicAuth, safeWebUrl } = require('./utils.cjs');
 
 const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
+
+/* ─── Duplicate-submission guard (F-012, CWE-362) ─────────────────────────
+ * APPROVE/REJECT/DELETE/MERGE each POST to Percy. A double-click on a slow
+ * connection, or two identical channel emits, would otherwise send two
+ * review/merge records. Track in-flight `<action>:<buildId>` keys and drop a
+ * duplicate while the first round-trip is pending; the first request's reply
+ * event resolves the UI, so the dropped duplicate needs no reply of its own.
+ */
+const inFlightReviewActions = new Set();
+
+function guardInFlight(event, handler) {
+  return async (payload, ...rest) => {
+    const key = `${event}:${String(payload?.buildId ?? '')}`;
+    if (inFlightReviewActions.has(key)) {
+      console.warn(`[percy] Ignoring duplicate "${event}" for build ${payload?.buildId} while one is already in flight.`);
+      return undefined;
+    }
+    inFlightReviewActions.add(key);
+    try {
+      return await handler(payload, ...rest);
+    } finally {
+      inFlightReviewActions.delete(key);
+    }
+  };
+}
 
 /* ─── Channel handlers ────────────────────────────────────────────────── */
 
 function registerBuildApiHandlers(channel) {
+  // Review actions register through this so duplicates are dropped in flight.
+  const onReviewAction = (event, handler) => channel.on(event, guardInFlight(event, handler));
+
   /**
    * FETCH_BUILD_STATUS
    * Polls Percy Build API for current build state.
@@ -60,7 +88,7 @@ function registerBuildApiHandlers(channel) {
         buildId: id,
         buildNumber: attrs['build-number'],
         state: attrs.state,
-        webUrl: attrs['web-url'],
+        webUrl: safeWebUrl(attrs['web-url']),
         failureReason: attrs['failure-reason'],
         totalSnapshots: attrs['total-snapshots'],
         totalComparisons: attrs['total-comparisons'],
@@ -134,7 +162,7 @@ function registerBuildApiHandlers(channel) {
    * Payload: { buildId }
    * Response: { buildId, success } or { error, buildId }
    */
-  channel.on(PERCY_EVENTS.APPROVE_BUILD, async ({ buildId }) => {
+  onReviewAction(PERCY_EVENTS.APPROVE_BUILD, async ({ buildId }) => {
     try {
       const id = validateBuildId(buildId);
       const { username, accessKey } = readBsCredentials();
@@ -183,7 +211,7 @@ function registerBuildApiHandlers(channel) {
    * Payload: { buildId }
    * Response: { buildId, success } or { error, buildId }
    */
-  channel.on(PERCY_EVENTS.REJECT_BUILD, async ({ buildId }) => {
+  onReviewAction(PERCY_EVENTS.REJECT_BUILD, async ({ buildId }) => {
     try {
       const id = validateBuildId(buildId);
       const { username, accessKey } = readBsCredentials();
@@ -232,7 +260,7 @@ function registerBuildApiHandlers(channel) {
    * Payload: { buildId }
    * Response: { buildId, success } or { error, buildId }
    */
-  channel.on(PERCY_EVENTS.DELETE_BUILD, async ({ buildId }) => {
+  onReviewAction(PERCY_EVENTS.DELETE_BUILD, async ({ buildId }) => {
     try {
       const id = validateBuildId(buildId);
       const { username, accessKey } = readBsCredentials();
@@ -314,7 +342,7 @@ function registerBuildApiHandlers(channel) {
    * Payload: { buildId }
    * Response: { buildId, success } or { error, buildId }
    */
-  channel.on(PERCY_EVENTS.MERGE_BUILD, async ({ buildId }) => {
+  onReviewAction(PERCY_EVENTS.MERGE_BUILD, async ({ buildId }) => {
     try {
       const id = validateBuildId(buildId);
       const { username, accessKey } = readBsCredentials();
@@ -355,4 +383,4 @@ function registerBuildApiHandlers(channel) {
   });
 }
 
-module.exports = { registerBuildApiHandlers };
+module.exports = { registerBuildApiHandlers, guardInFlight };

--- a/src/server/env.cjs
+++ b/src/server/env.cjs
@@ -102,4 +102,6 @@ module.exports = {
   setKey,
   readEnv,
   readEnvRaw,
-  writeEnvRaw, assertSafeEnvValue };
+  writeEnvRaw,
+  assertSafeEnvValue
+};

--- a/src/server/env.cjs
+++ b/src/server/env.cjs
@@ -31,12 +31,36 @@ function parseEnv(content) {
 }
 
 /**
+ * Reject values that would corrupt .env for this parser or for downstream
+ * dotenv-style parsers (F-018, CWE-93):
+ *  - '\n' / '\r'   → line break: the remainder becomes a new KEY=VALUE line
+ *  - '#'           → comment marker: dotenv drops the remainder of the value
+ *  - '='           → split-on-first-'=' ambiguity in naive parsers
+ *  - '\0'          → null byte
+ *  - leading/trailing whitespace → silently trimmed by some parsers, not others
+ * Every value written here is a BrowserStack username, an access key, a Percy
+ * token or a numeric build id, none of which legitimately contain these.
+ */
+function assertSafeEnvValue(key, value) {
+  const str = String(value);
+  const reason =
+    str.includes('\n') ? 'contains newline'
+      : str.includes('\r') ? 'contains carriage return'
+        : str.includes('\0') ? 'contains null byte'
+          : str.includes('#') ? "contains '#'"
+            : str.includes('=') ? "contains '='"
+              : str !== str.trim() ? 'has leading or trailing whitespace'
+                : null;
+  if (reason) throw new Error(`Invalid value for ${key}: ${reason}`);
+  return str;
+}
+
+/**
  * Set or update a key=value in .env content string.
- * Escapes key for regex safety and rejects newlines in value.
+ * Rejects values that would break the file (see assertSafeEnvValue).
  */
 function setKey(src, key, value) {
-  if (String(value).includes('\n')) throw new Error(`Invalid value for ${key}: contains newline`);
-  const line = `${key}=${value}`;
+  const line = `${key}=${assertSafeEnvValue(key, value)}`;
   const lines = src.split('\n');
   const prefix = `${key}=`;
   const idx = lines.findIndex(l => l.trimStart().startsWith(prefix));
@@ -78,5 +102,4 @@ module.exports = {
   setKey,
   readEnv,
   readEnvRaw,
-  writeEnvRaw
-};
+  writeEnvRaw, assertSafeEnvValue };

--- a/src/server/projectConfig.cjs
+++ b/src/server/projectConfig.cjs
@@ -5,7 +5,7 @@ const { PERCY_EVENTS } = require('../constants.cjs');
 const { getPercyYmlPath, readEnv, readEnvRaw, setKey, writeEnvRaw } = require('./env.cjs');
 const { readBsCredentials, resolveBsCredentials } = require('./credentials.cjs');
 const { loggedFetch } = require('./apiLogger.cjs');
-const { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth } = require('./utils.cjs');
+const { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth, safeWebUrl } = require('./utils.cjs');
 
 /* ─── .percy.yml helpers ───────────────────────────────────────────────── */
 
@@ -214,7 +214,7 @@ async function fetchLastBuild(buildIdRaw, username, accessKey) {
     buildId: id,
     state: attrs.state,
     buildNumber: attrs['build-number'],
-    webUrl: attrs['web-url'],
+    webUrl: safeWebUrl(attrs['web-url']),
     reviewState: attrs['review-state'] || null,
     reviewStateReason: attrs['review-state-reason'] || null,
     headBranch,

--- a/src/server/utils.cjs
+++ b/src/server/utils.cjs
@@ -33,4 +33,23 @@ function basicAuth(username, accessKey) {
   return Buffer.from(`${username}:${accessKey}`).toString('base64');
 }
 
-module.exports = { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth };
+/**
+ * Return `value` only if it is an absolute https: URL, else null.
+ *
+ * Build/project web URLs come from percy.io API responses and end up in
+ * `href` and `window.open` in the manager. A tampered response — or a forged
+ * client-side BUILD_STATUS_FETCHED emit, which the nonce gate does not cover —
+ * could otherwise deliver `javascript:` into the manager context (F-023,
+ * CWE-79). Scheme-pinning is deliberate; the hostname is not pinned so a Percy
+ * web domain change does not silently break every link.
+ */
+function safeWebUrl(value) {
+  if (typeof value !== 'string' || !value) return null;
+  try {
+    return new URL(value).protocol === 'https:' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth, safeWebUrl };

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -184,6 +184,24 @@ function processAdditionalSnapshots(additionalSnapshots, baseOptions, storyName,
 }
 
 // Map and reduce collected Storybook stories into an array of snapshot options
+/**
+ * Build the preview URL for a story. `queryParams` is story-author input, so
+ * both key and value are percent-encoded: an unencoded `&`, `=` or `#` in
+ * either would inject extra parameters into the URL (F-021).
+ */
+export function buildStoryUrl(previewUrl, story) {
+  let url = `${previewUrl}?id=${story.id}`;
+  if (story.args) url += `&args=${buildStorybookArgsParam(story.args)}`;
+  if (story.globals) url += `&globals=${buildStorybookArgsParam(story.globals)}`;
+  for (let [k, v] of Object.entries(story.queryParams ?? {})) {
+    url += `&${encodeURIComponent(k)}=${encodeURIComponent(v ?? '')}`;
+  }
+  if (!story.queryParams?.viewMode) {
+    url += `&viewMode=${viewModeFor(story)}`;
+  }
+  return url;
+}
+
 function mapStorybookSnapshots(stories, { previewUrl, flags, config, globalDocSettings }) {
   let log = logger('storybook:config');
   let invalid = new Map(stories.invalid);
@@ -231,14 +249,7 @@ function mapStorybookSnapshots(stories, { previewUrl, flags, config, globalDocSe
 
   // remove filter options and generate story snapshot URLs
   return snapshots.map(({ skip, include, exclude, ...story }) => {
-    let url = `${previewUrl}?id=${story.id}`;
-    if (story.args) url += `&args=${buildStorybookArgsParam(story.args)}`;
-    if (story.globals) url += `&globals=${buildStorybookArgsParam(story.globals)}`;
-    for (let [k, v] of Object.entries(story.queryParams ?? {})) url += `&${k}=${v}`;
-    if (!story.queryParams?.viewMode) {
-      url += `&viewMode=${viewModeFor(story)}`;
-    }
-    return Object.assign(story, { url });
+    return Object.assign(story, { url: buildStoryUrl(previewUrl, story) });
   });
 }
 

--- a/src/snapshots.js
+++ b/src/snapshots.js
@@ -185,16 +185,21 @@ function processAdditionalSnapshots(additionalSnapshots, baseOptions, storyName,
 
 // Map and reduce collected Storybook stories into an array of snapshot options
 /**
- * Build the preview URL for a story. `queryParams` is story-author input, so
- * both key and value are percent-encoded: an unencoded `&`, `=` or `#` in
- * either would inject extra parameters into the URL (F-021).
+ * Build the preview URL for a story.
+ *
+ * `queryParams` is story-author input. Its VALUES are already percent-encoded
+ * when they are collected from the story in the browser
+ * (evalStorybookStorySnapshots → serialize('queryParams') in utils.js), so they
+ * are appended as-is here — encoding again would double-encode (`%20` → `%2520`).
+ * Its KEYS were never encoded, which let `&`, `=` or `#` in a key inject extra
+ * parameters into the URL (F-021); they are encoded here.
  */
 export function buildStoryUrl(previewUrl, story) {
   let url = `${previewUrl}?id=${story.id}`;
   if (story.args) url += `&args=${buildStorybookArgsParam(story.args)}`;
   if (story.globals) url += `&globals=${buildStorybookArgsParam(story.globals)}`;
   for (let [k, v] of Object.entries(story.queryParams ?? {})) {
-    url += `&${encodeURIComponent(k)}=${encodeURIComponent(v ?? '')}`;
+    url += `&${encodeURIComponent(k)}=${v ?? ''}`;
   }
   if (!story.queryParams?.viewMode) {
     url += `&viewMode=${viewModeFor(story)}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -705,6 +705,29 @@ export async function captureSerializedDOM(page, options, log) {
 }
 
 // Capture responsive DOM snapshots across different widths
+// Upper bound for RESPONSIVE_CAPTURE_SLEEP_TIME. The sleep runs once per width
+// per story, so an unbounded value (a typo, or a hostile CI env) hangs the run
+// for stories × widths × sleep while holding the build, browser and dev server
+// open (F-022, CWE-400). 60s per capture is already far beyond any real need.
+export const MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS = 60;
+
+/**
+ * Parse RESPONSIVE_CAPTURE_SLEEP_TIME into a bounded number of seconds.
+ * Invalid / negative → 0 (warn). Above the cap → cap (warn).
+ */
+export function resolveResponsiveCaptureSleepSeconds(raw, log) {
+  let sleepTime = parseInt(raw, 10);
+  if (isNaN(sleepTime) || sleepTime < 0) {
+    log.warn(`Invalid value for RESPONSIVE_CAPTURE_SLEEP_TIME: "${raw}". Using fallback value of 0 seconds.`);
+    return 0;
+  }
+  if (sleepTime > MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS) {
+    log.warn(`RESPONSIVE_CAPTURE_SLEEP_TIME=${raw} exceeds the maximum of ${MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS} seconds. Clamping to ${MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS}.`);
+    return MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS;
+  }
+  return sleepTime;
+}
+
 export async function captureResponsiveDOM(page, options, percy, log, story) {
   const domSnapshots = [];
 
@@ -782,11 +805,7 @@ export async function captureResponsiveDOM(page, options, percy, log, story) {
 
     // RESPONSIVE_CAPTURE_SLEEP_TIME: (number, seconds) If set, waits this many seconds before capturing each snapshot.
     if (process.env.RESPONSIVE_CAPTURE_SLEEP_TIME) {
-      let sleepTime = parseInt(process.env.RESPONSIVE_CAPTURE_SLEEP_TIME, 10);
-      if (isNaN(sleepTime) || sleepTime < 0) {
-        log.warn(`Invalid value for RESPONSIVE_CAPTURE_SLEEP_TIME: "${process.env.RESPONSIVE_CAPTURE_SLEEP_TIME}". Using fallback value of 0 seconds.`);
-        sleepTime = 0;
-      }
+      const sleepTime = resolveResponsiveCaptureSleepSeconds(process.env.RESPONSIVE_CAPTURE_SLEEP_TIME, log);
       log.debug(`Sleeping for ${sleepTime} seconds before capturing snapshot`);
       await new Promise(resolve => setTimeout(resolve, sleepTime * 1000));
     }

--- a/src/utils/safeUrl.js
+++ b/src/utils/safeUrl.js
@@ -1,0 +1,18 @@
+/**
+ * Percy Storybook Addon – manager-side URL guard (pure, no React).
+ *
+ * Build/project URLs arrive over the server channel. The server already
+ * scheme-checks what it emits (server/utils.cjs safeWebUrl), but a forged
+ * client-side emit bypasses the server entirely, so every `href` /
+ * `window.open` in the manager re-checks here as defence in depth (F-023).
+ */
+
+/** Return `value` only if it is an absolute https: URL, else null. */
+export function safeHttpsUrl(value) {
+  if (typeof value !== 'string' || !value) return null;
+  try {
+    return new URL(value).protocol === 'https:' ? value : null;
+  } catch {
+    return null;
+  }
+}

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -17,24 +17,36 @@ describe('buildStoryUrl (F-021, PER-8549)', () => {
     expect(url).toBe('http://localhost:6006/iframe.html?id=s&viewMode=story');
   });
 
-  it('percent-encodes queryParams keys AND values so they cannot inject extra parameters', () => {
+  it('percent-encodes queryParams KEYS so a crafted key cannot inject extra parameters', () => {
+    // The ticket's payload: a key carrying `=` and `&`.
     const url = buildStoryUrl(previewUrl, {
       id: 's',
-      queryParams: { viewMode: 'story', 'legitKey=injected&anotherKey': 'v&evil=1#frag', theme: 'dark mode' }
+      queryParams: { viewMode: 'story', 'legitKey=injected&anotherKey': 'value', 'a#b': 'c' }
     });
     expect(url).toBe(
       'http://localhost:6006/iframe.html?id=s' +
       '&viewMode=story' +
-      '&legitKey%3Dinjected%26anotherKey=v%26evil%3D1%23frag' +
-      '&theme=dark%20mode'
+      '&legitKey%3Dinjected%26anotherKey=value' +
+      '&a%23b=c'
     );
-    // exactly the four intended parameters, nothing injected
+    // exactly the three intended parameters, nothing injected
     expect(url.split('&').length).toBe(4);
   });
 
-  it('stringifies non-string values and treats null/undefined as empty', () => {
-    const url = buildStoryUrl(previewUrl, { id: 's', queryParams: { viewMode: 'story', n: 5, t: true, e: null } });
-    expect(url).toBe('http://localhost:6006/iframe.html?id=s&viewMode=story&n=5&t=true&e=');
+  it('appends VALUES as-is because the collector already percent-encoded them (no double-encoding)', () => {
+    // evalStorybookStorySnapshots serialises queryParams values with
+    // encodeURIComponent before they reach the CLI, so ' with query params'
+    // arrives as '%20with%20query%20params' and must come out unchanged.
+    const url = buildStoryUrl(previewUrl, {
+      id: 's', queryParams: { viewMode: 'story', text: '%20with%20query%20params', pct: '100%25' }
+    });
+    expect(url).toBe('http://localhost:6006/iframe.html?id=s&viewMode=story&text=%20with%20query%20params&pct=100%25');
+    expect(url).not.toContain('%2520');
+  });
+
+  it('treats null/undefined values as empty', () => {
+    const url = buildStoryUrl(previewUrl, { id: 's', queryParams: { viewMode: 'story', e: null, u: undefined } });
+    expect(url).toBe('http://localhost:6006/iframe.html?id=s&viewMode=story&e=&u=');
   });
 });
 

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -1,7 +1,42 @@
 import * as utils from '../src/utils.js';
 import { IntelliStoryBailError, PercyConfig } from '@percy/cli-command';
 import * as CoreConfig from '@percy/core/config';
-import { applyIntelliStoryFilter, processStory } from '../src/snapshots.js';
+import { applyIntelliStoryFilter, processStory, buildStoryUrl } from '../src/snapshots.js';
+
+describe('buildStoryUrl (F-021, PER-8549)', () => {
+  const previewUrl = 'http://localhost:6006/iframe.html';
+
+  it('builds the plain story URL and appends viewMode when none is given', () => {
+    const url = buildStoryUrl(previewUrl, { id: 'button--primary' });
+    expect(url.startsWith('http://localhost:6006/iframe.html?id=button--primary')).toBe(true);
+    expect(url).toMatch(/&viewMode=\w+$/);
+  });
+
+  it('keeps a caller-supplied viewMode instead of appending one', () => {
+    const url = buildStoryUrl(previewUrl, { id: 's', queryParams: { viewMode: 'story' } });
+    expect(url).toBe('http://localhost:6006/iframe.html?id=s&viewMode=story');
+  });
+
+  it('percent-encodes queryParams keys AND values so they cannot inject extra parameters', () => {
+    const url = buildStoryUrl(previewUrl, {
+      id: 's',
+      queryParams: { viewMode: 'story', 'legitKey=injected&anotherKey': 'v&evil=1#frag', theme: 'dark mode' }
+    });
+    expect(url).toBe(
+      'http://localhost:6006/iframe.html?id=s' +
+      '&viewMode=story' +
+      '&legitKey%3Dinjected%26anotherKey=v%26evil%3D1%23frag' +
+      '&theme=dark%20mode'
+    );
+    // exactly the four intended parameters, nothing injected
+    expect(url.split('&').length).toBe(4);
+  });
+
+  it('stringifies non-string values and treats null/undefined as empty', () => {
+    const url = buildStoryUrl(previewUrl, { id: 's', queryParams: { viewMode: 'story', n: 5, t: true, e: null } });
+    expect(url).toBe('http://localhost:6006/iframe.html?id=s&viewMode=story&n=5&t=true&e=');
+  });
+});
 
 describe('captureDOM behavior', () => {
   let page, percy, log, previewResource, captureDOM;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,7 +1,20 @@
 import { validateStoryArgs, encodeStoryArgs, decodeStoryArgs } from '../src/utils.js';
 import { canFetchProjects, credentialsFromConfigLoaded } from '../src/utils/credentials.js';
+import { safeHttpsUrl } from '../src/utils/safeUrl.js';
 
 describe('Unit /', () => {
+  describe('safeHttpsUrl (F-023)', () => {
+    it('passes absolute https: URLs through', () => {
+      expect(safeHttpsUrl('https://percy.io/org/proj/builds/1')).toBe('https://percy.io/org/proj/builds/1');
+    });
+
+    it('rejects javascript:, data:, http:, relative and malformed values', () => {
+      for (const bad of ['javascript:alert(1)', 'data:text/html,x', 'http://percy.io/x', '//percy.io/x', '/builds/1', 'nope', '', null, undefined]) {
+        expect(safeHttpsUrl(bad)).withContext(String(bad)).toBeNull();
+      }
+    });
+  });
+
   describe('canFetchProjects', () => {
     // Regression: after the server stopped sending the access key to the
     // browser (F-017), a startup restore or "Change project" left the picker

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1411,3 +1411,34 @@ describe('generateDocRuleOptions', () => {
     });
   });
 });
+
+describe('resolveResponsiveCaptureSleepSeconds (F-022, PER-8551)', () => {
+  let log;
+  beforeEach(() => { log = { warn: jasmine.createSpy('warn'), debug: jasmine.createSpy('debug') }; });
+
+  it('returns the parsed value when it is within bounds', () => {
+    expect(utils.resolveResponsiveCaptureSleepSeconds('2', log)).toBe(2);
+    expect(utils.resolveResponsiveCaptureSleepSeconds('0', log)).toBe(0);
+    expect(utils.resolveResponsiveCaptureSleepSeconds(String(utils.MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS), log))
+      .toBe(utils.MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to 0 with a warning for NaN or negative values', () => {
+    expect(utils.resolveResponsiveCaptureSleepSeconds('abc', log)).toBe(0);
+    expect(utils.resolveResponsiveCaptureSleepSeconds('-5', log)).toBe(0);
+    expect(log.warn).toHaveBeenCalledTimes(2);
+    expect(log.warn.calls.argsFor(0)[0]).toContain('Invalid value for RESPONSIVE_CAPTURE_SLEEP_TIME');
+  });
+
+  it('clamps values above the maximum with a warning (no unbounded per-width hang)', () => {
+    expect(utils.resolveResponsiveCaptureSleepSeconds('3600', log)).toBe(utils.MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS);
+    expect(utils.resolveResponsiveCaptureSleepSeconds('999999999', log)).toBe(utils.MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS);
+    expect(log.warn).toHaveBeenCalledTimes(2);
+    expect(log.warn.calls.argsFor(0)[0]).toContain('exceeds the maximum');
+  });
+
+  it('the maximum is 60 seconds', () => {
+    expect(utils.MAX_RESPONSIVE_CAPTURE_SLEEP_SECONDS).toBe(60);
+  });
+});

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -3586,7 +3586,7 @@ describe('Manager / wiring contracts', () => {
     // Manager: both consumers import the guard and run every URL through it.
     const rh = read('src/components/ReviewHeader.jsx');
     expect(rh).toContain("import { safeHttpsUrl } from '../utils/safeUrl.js'");
-    expect(rh).toContain('const safeWebUrl = safeHttpsUrl(webUrl)');   // -> window.open(settingsUrl)
+    expect(rh).toContain('const safeWebUrl = safeHttpsUrl(webUrl)'); // -> window.open(settingsUrl)
     expect(rh).toContain('href={safeHttpsUrl(webUrl)}');
     expect(rh).not.toMatch(/href=\{webUrl\}/);
     expect(rh).not.toMatch(/window\.open\(\s*webUrl/);

--- a/test/zz-server.test.js
+++ b/test/zz-server.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { PERCY_EVENTS, CHANNEL_AUTH } from '../src/constants.cjs';
 import { CHANNEL_AUTH as CHANNEL_AUTH_ESM, PERCY_EVENTS as PERCY_EVENTS_ESM } from '../src/constants.js';
 import * as preset from '../preset.cjs';
-import { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth } from '../src/server/utils.cjs';
+import { PERCY_API_BASE, validateBuildId, validateProjectId, basicAuth, safeWebUrl } from '../src/server/utils.cjs';
 import { withNonce, getPercyNonce } from '../src/utils/channelNonce.js';
 import { canFetchProjects, credentialsFromConfigLoaded } from '../src/utils/credentials.js';
 import {
@@ -19,7 +19,7 @@ import {
 import { registerPercyApiHandlers } from '../src/server/percyApi.cjs';
 import { registerBuildItemsHandlers } from '../src/server/buildItems.cjs';
 import { registerSnapshotDetailHandlers } from '../src/server/snapshotDetail.cjs';
-import { registerBuildApiHandlers } from '../src/server/buildApi.cjs';
+import { registerBuildApiHandlers, guardInFlight } from '../src/server/buildApi.cjs';
 import {
   readPercyYml, writePercyYml, fetchPercyToken, setPercyToken,
   registerProjectConfigHandlers
@@ -134,6 +134,23 @@ describe('Server / utils.cjs', () => {
 /*  2. env.cjs                                                           */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
+describe('Server / utils.cjs — safeWebUrl (F-023)', () => {
+  it('passes an absolute https: URL through unchanged', () => {
+    expect(safeWebUrl('https://percy.io/org/proj/builds/123')).toBe('https://percy.io/org/proj/builds/123');
+    expect(safeWebUrl('https://example.com/x?y=1#z')).toBe('https://example.com/x?y=1#z');
+  });
+
+  it('rejects every non-https scheme and every non-URL', () => {
+    for (const bad of [
+      'javascript:alert(document.cookie)', 'JavaScript:alert(1)', 'data:text/html,<script>1</script>',
+      'http://percy.io/insecure', 'ftp://percy.io/x', '//percy.io/protocol-relative', 'percy.io/no-scheme',
+      '/builds/1', 'not a url', '', null, undefined, 42, {}
+    ]) {
+      expect(safeWebUrl(bad)).withContext(String(bad)).toBeNull();
+    }
+  });
+});
+
 describe('Server / env.cjs', () => {
   describe('getEnvPath', () => {
     it('returns .env in cwd', () => {
@@ -174,6 +191,26 @@ describe('Server / env.cjs', () => {
   });
 
   describe('setKey', () => {
+    // F-018 (PER-8549): values that would corrupt .env for this parser or a
+    // downstream dotenv-style parser are rejected, not written.
+    it('rejects values that would break .env parsing', () => {
+      expect(() => setKey('', 'K', 'a\rb')).toThrowError(/contains carriage return/);
+      expect(() => setKey('', 'K', 'a\0b')).toThrowError(/contains null byte/);
+      expect(() => setKey('', 'K', 'key#comment')).toThrowError(/contains '#'/);
+      expect(() => setKey('', 'K', 'a=b')).toThrowError(/contains '='/);
+      expect(() => setKey('', 'K', ' padded')).toThrowError(/leading or trailing whitespace/);
+      expect(() => setKey('', 'K', 'padded ')).toThrowError(/leading or trailing whitespace/);
+    });
+
+    it('still accepts every value shape the addon actually writes', () => {
+      // username, access key, Percy token, numeric build id, cleared build id
+      expect(setKey('', 'BROWSERSTACK_USERNAME', 'ninad_abc123')).toBe('BROWSERSTACK_USERNAME=ninad_abc123\n');
+      expect(setKey('', 'BROWSERSTACK_ACCESS_KEY', 'AbCdEf1234567890xyz')).toBe('BROWSERSTACK_ACCESS_KEY=AbCdEf1234567890xyz\n');
+      expect(setKey('', 'PERCY_TOKEN', 'web_0123456789abcdef0123456789abcdef')).toBe('PERCY_TOKEN=web_0123456789abcdef0123456789abcdef\n');
+      expect(setKey('', 'PERCY_LAST_TRIGGER_BUILD', '123456')).toBe('PERCY_LAST_TRIGGER_BUILD=123456\n');
+      expect(setKey('', 'PERCY_LAST_TRIGGER_BUILD', '')).toBe('PERCY_LAST_TRIGGER_BUILD=\n');
+    });
+
     it('appends a new key to empty source', () => {
       expect(setKey('', 'FOO', 'bar')).toBe('FOO=bar\n');
     });
@@ -1778,6 +1815,17 @@ describe('Server / buildApi.cjs', () => {
       meta: { total: 1 }
     };
 
+    it('neutralises a non-https web-url before it reaches the browser (F-023)', async () => {
+      const tampered = JSON.parse(JSON.stringify(buildJson));
+      tampered.data.attributes['web-url'] = 'javascript:alert(document.cookie)';
+      globalThis.fetch = jasmine.createSpy('fetch').and.resolveTo(mockResponse(tampered));
+
+      await channel.trigger(PERCY_EVENTS.FETCH_BUILD_STATUS, { buildId: '10' });
+      const payload = channel.emit.calls.mostRecent().args[1];
+      expect(payload.webUrl).toBeNull();
+      expect(payload.state).toBe('finished'); // the rest of the status still flows
+    });
+
     it('emits full build status on success', async () => {
       globalThis.fetch = jasmine.createSpy('fetch').and.resolveTo(mockResponse(buildJson));
 
@@ -1967,7 +2015,60 @@ describe('Server / buildApi.cjs', () => {
     });
   });
 
+  describe('guardInFlight (F-012, PER-8548)', () => {
+    beforeEach(() => spyOn(console, 'warn'));
+
+    it('drops a duplicate for the same build while the first is in flight, allows other builds', async () => {
+      let calls = 0; const releases = [];
+      const handler = guardInFlight('ev', async () => { calls++; await new Promise(r => releases.push(r)); });
+      const p1 = handler({ buildId: '1' });
+      const p2 = handler({ buildId: '1' }); // duplicate — dropped
+      const p3 = handler({ buildId: '2' }); // different build — allowed
+      expect(calls).toBe(2);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      releases.forEach(r => r());
+      await Promise.all([p1, p2, p3]);
+    });
+
+    it('allows the same build again once the first round-trip has settled', async () => {
+      let calls = 0;
+      const handler = guardInFlight('ev', async () => { calls++; });
+      await handler({ buildId: '1' });
+      await handler({ buildId: '1' });
+      expect(calls).toBe(2);
+    });
+
+    it('releases the key when the handler throws', async () => {
+      let calls = 0;
+      const handler = guardInFlight('ev', async () => { calls++; throw new Error('boom'); });
+      await expectAsync(handler({ buildId: '1' })).toBeRejected();
+      await expectAsync(handler({ buildId: '1' })).toBeRejected();
+      expect(calls).toBe(2);
+    });
+  });
+
   describe('APPROVE_BUILD', () => {
+    it('sends ONE review when the same approve is emitted twice concurrently (F-012)', async () => {
+      spyOn(console, 'warn');
+      let resolveFetch;
+      globalThis.fetch = jasmine.createSpy('fetch').and.returnValue(new Promise(r => { resolveFetch = r; }));
+
+      const p1 = channel.trigger(PERCY_EVENTS.APPROVE_BUILD, { buildId: '10' });
+      const p2 = channel.trigger(PERCY_EVENTS.APPROVE_BUILD, { buildId: '10' });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+      resolveFetch(mockResponse({}));
+      await Promise.all([p1, p2]);
+      const approved = channel.emit.calls.allArgs().filter(a => a[0] === PERCY_EVENTS.BUILD_APPROVED);
+      expect(approved.length).toBe(1);
+      expect(approved[0][1]).toEqual({ buildId: '10', success: true });
+
+      // and a later, separate approve is not blocked
+      globalThis.fetch = jasmine.createSpy('fetch').and.resolveTo(mockResponse({}));
+      await channel.trigger(PERCY_EVENTS.APPROVE_BUILD, { buildId: '10' });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
     it('emits success on ok response', async () => {
       globalThis.fetch = jasmine.createSpy('fetch').and.resolveTo(mockResponse({}));
 
@@ -2115,6 +2216,17 @@ describe('Server / buildApi.cjs', () => {
   });
 
   describe('MERGE_BUILD', () => {
+    it('sends ONE merge when the same merge is emitted twice concurrently (F-012)', async () => {
+      spyOn(console, 'warn');
+      let resolveFetch;
+      globalThis.fetch = jasmine.createSpy('fetch').and.returnValue(new Promise(r => { resolveFetch = r; }));
+      const p1 = channel.trigger(PERCY_EVENTS.MERGE_BUILD, { buildId: '10' });
+      const p2 = channel.trigger(PERCY_EVENTS.MERGE_BUILD, { buildId: '10' });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      resolveFetch(mockResponse({}));
+      await Promise.all([p1, p2]);
+    });
+
     it('emits success on ok response', async () => {
       globalThis.fetch = jasmine.createSpy('fetch').and.resolveTo(mockResponse({}));
 
@@ -3465,6 +3577,26 @@ describe('Manager / wiring contracts', () => {
     expect(read('src/components/PercyPanel.jsx')).toContain('storedOnServer={credentials.storedOnServer}');
     expect(read('src/components/ProjectSetup.jsx')).toMatch(/usePercyProjects\(username,\s*accessKey,\s*initialSearch,\s*storedOnServer\)/);
     expect(read('src/hooks/usePercyProjects.js')).toContain('canFetchProjects(username, accessKey, storedOnServer)');
+  });
+
+  it('every build/project URL sink is scheme-checked (F-023)', () => {
+    // Server: both emitters of a percy.io web-url pass it through safeWebUrl.
+    expect(read('src/server/buildApi.cjs')).toContain("webUrl: safeWebUrl(attrs['web-url'])");
+    expect(read('src/server/projectConfig.cjs')).toContain("webUrl: safeWebUrl(attrs['web-url'])");
+    // Manager: both consumers import the guard and run every URL through it.
+    const rh = read('src/components/ReviewHeader.jsx');
+    expect(rh).toContain("import { safeHttpsUrl } from '../utils/safeUrl.js'");
+    expect(rh).toContain('const safeWebUrl = safeHttpsUrl(webUrl)');   // -> window.open(settingsUrl)
+    expect(rh).toContain('href={safeHttpsUrl(webUrl)}');
+    expect(rh).not.toMatch(/href=\{webUrl\}/);
+    expect(rh).not.toMatch(/window\.open\(\s*webUrl/);
+    const bp = read('src/components/BuildProgress.jsx');
+    expect(bp).toContain("import { safeHttpsUrl } from '../utils/safeUrl.js'");
+    // BuildProgress keeps the `webUrl` name but derives it from the guard, so
+    // every later `href={webUrl}` in that file is already sanitised.
+    expect(bp).toContain('const webUrl = safeHttpsUrl(buildData?.webUrl || buildUrl)');
+    expect(bp).toContain('webUrl: safeHttpsUrl(buildData.webUrl || buildUrl)');
+    expect(bp).not.toMatch(/const webUrl = buildData\?\.webUrl \|\| buildUrl;/);
   });
 
   it('snapshot load errors are checked before the loading fallback', () => {


### PR DESCRIPTION
## Summary
Closes the last open code findings from the percy-storybook security batch. Each is small and independent; grouped because they share a release.

### PER-8549 — Input-validation cluster, remaining 3 of 5 sinks
- **F-018 `.env` value injection** — `setKey` (`src/server/env.cjs`) now rejects `\r`, `\0`, `#`, `=` and leading/trailing whitespace (newline was already rejected). Values the addon actually writes — username, access key, Percy token, numeric build id, empty string — are all still accepted (tested).
- **F-021 unencoded `queryParams`** — story URL building extracted to `buildStoryUrl()` (`src/snapshots.js`); **keys** are now `encodeURIComponent`'d. Values were *already* percent-encoded at collection (`evalStorybookStorySnapshots` → `serialize('queryParams')` in `utils.js`), so they are appended as-is — an earlier revision of this PR encoded them again, double-encoding `%20` → `%2520`, and the existing story-URL test caught it. No user-visible behaviour change: the key was the only unencoded sink.
- **F-023 unvalidated `webUrl`** — `safeWebUrl()` (server, `src/server/utils.cjs`) and `safeHttpsUrl()` (manager, `src/utils/safeUrl.js`) return the value only for an absolute `https:` URL. Applied at both server emitters (`buildApi.cjs` FETCH_BUILD_STATUS, `projectConfig.cjs` fetchLastBuild) and at every manager sink (`ReviewHeader` href + settings `window.open`, `BuildProgress` href). Manager-side check is defence in depth: a forged client-side `BUILD_STATUS_FETCHED` emit bypasses the server and the nonce gate. Scheme pinned, hostname deliberately not (a Percy web-domain change must not silently kill every link).

### PER-8548 — F-012 duplicate review actions
`APPROVE_BUILD` / `REJECT_BUILD` / `DELETE_BUILD` / `MERGE_BUILD` register through `guardInFlight()`: a second emit for the same `<action>:<buildId>` while the first round-trip is pending is dropped (warn), key released in `finally`. The first request's reply resolves the UI, so the dropped duplicate needs no reply. Same shape as the existing `RUN_SNAPSHOT` in-flight guard. The ticket's `Idempotency-Key` header suggestion is not implemented — percy-api does not consume one.

### PER-8551 — F-022 unbounded `RESPONSIVE_CAPTURE_SLEEP_TIME`
Parsing extracted to `resolveResponsiveCaptureSleepSeconds()`; values above **60 s** are clamped with a warning. Behaviour note: anyone deliberately sleeping longer than 60 s per width per story now gets 60 s. That is already far beyond any real settle time; if a legitimate case turns up the cap is one constant.

### Not in this PR
- **PER-8553 lodash** — a patched `lodash@4.18.0` now exists (it did not when the ticket was filed). Needs `yarn` to regenerate the lockfile, which the authoring sandbox cannot run; separate PR.

## Tests
- `setKey`: every rejected class; every real value shape still accepted.
- `safeWebUrl` / `safeHttpsUrl`: https passes; `javascript:`, `data:`, `http:`, protocol-relative, relative, malformed, non-string all `null`.
- `FETCH_BUILD_STATUS`: a `javascript:` `web-url` from the API reaches the browser as `null`, rest of the payload intact.
- `guardInFlight`: duplicate dropped, other build allowed, released after completion and after a throw; plus concurrent `APPROVE_BUILD` and `MERGE_BUILD` through the real handlers → exactly one upstream POST, one reply.
- `buildStoryUrl`: plain, caller viewMode kept, the ticket's injection payload (`legitKey=injected&anotherKey`) yields exactly the intended parameter count, pre-encoded values are **not** double-encoded, null/undefined values.
- `resolveResponsiveCaptureSleepSeconds`: in-range, NaN/negative → 0 + warn, above cap → 60 + warn.
- Source guards: both server emitters and both manager consumers go through the URL guard; no raw `href={webUrl}` / `window.open(webUrl` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

