### PR TITLE
security(PER-8553): bump lodash to 4.18.1 and force it for every transitive path

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "immer": "9.0.21",
     "jasmine": "^4.5.0",
     "jasmine-spec-reporter": "^7.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "mock-require": "^3.0.3",
     "nock": "^13.2.9",
     "nyc": "^17.1.0",
@@ -154,6 +154,7 @@
     "vite": "6"
   },
   "resolutions": {
-    "jackspeak": "2.1.1"
+    "jackspeak": "2.1.1",
+    "lodash": "4.18.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8462,10 +8462,10 @@ lodash.values@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
   integrity sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==
 
-lodash@4.17.21, lodash@^4.17.20, lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.17.20, lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 long@^5.0.0, long@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
## Summary
GHSA-r5fr-rjxr-66jc / CVE-2026-4800 (code injection via `_.template` `imports` key names) affects `lodash <= 4.17.23`. When PER-8553 was filed there was no fix. There is now:

- **4.18.0** — patched, but **deprecated on npm**: *"Bad release. Please use lodash@4.17.21 instead."* Not used.
- **4.18.1** — current `latest`, patched, no deprecation. **This PR pins 4.18.1.**

`lodash` is a build-time devDependency and is not imported by the addon's own source; the exposure is the CI build environment via transitive use in the Storybook/webpack chain. The `resolutions` entry forces every transitive `lodash@^4.17.x` range onto 4.18.1, which is the ticket's remediation once a patched release exists.


## Risk
`4.18.x` is the first lodash release line in years; 4.18.0 was pulled as a bad release. 4.18.1 is what the maintainers now publish as `latest`, but the build chain (webpack, html-webpack-plugin, Storybook) exercises lodash at build time, so **the local `yarn build` above is the real check**, not the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
